### PR TITLE
chore: Remove PUB_RAND_VALUES storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#39](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Remove
+  PUB_RAND_VALUES storage.
 * [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename `hash` to `hash_hex`.
 * [#23](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/23) Clean up dependencies to cosmos-bsn-contracts.
 * [#24](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/24) Validate public randomness commitment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### State breaking
 
 * [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore: use consistent naming for state maps
+* [#39](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Remove
+  PUB_RAND_VALUES storage.
 
 ### Improvements
 
-* [#39](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Remove
-  PUB_RAND_VALUES storage.
 * [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename `hash` to `hash_hex`.
 * [#23](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/23) Clean up dependencies to cosmos-bsn-contracts.
 * [#24](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/24) Validate public randomness commitment.

--- a/SPEC.md
+++ b/SPEC.md
@@ -596,12 +596,6 @@ This section documents the actual state storage structure used by the finality c
   }
   ```
 
-**PUB_RAND_VALUES**: Individual public randomness values
-- Type: `Map<(&str, u64), Vec<u8>>`
-- Storage key: `"fp_pub_rand"`
-- Key format: `(fp_pubkey_hex, block_height)`
-- Purpose: Stores individual public randomness values revealed during finality signature submission
-
 ### 5.6. Finality contract queries
 
 The finality contract query requirements are divided into core finality

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -5,9 +5,7 @@ use crate::msg::BabylonMsg;
 use crate::queries::query_last_pub_rand_commit;
 use crate::state::config::CONFIG;
 use crate::state::finality::{Evidence, BLOCK_HASHES, BLOCK_VOTES, EVIDENCES, SIGNATURES};
-use crate::state::public_randomness::{
-    get_pub_rand_commit_for_height, PUB_RAND_COMMITS,
-};
+use crate::state::public_randomness::{get_pub_rand_commit_for_height, PUB_RAND_COMMITS};
 use crate::utils::query_finality_provider;
 
 use crate::state::public_randomness::PubRandCommit;

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -6,7 +6,7 @@ use crate::queries::query_last_pub_rand_commit;
 use crate::state::config::CONFIG;
 use crate::state::finality::{Evidence, BLOCK_HASHES, BLOCK_VOTES, EVIDENCES, SIGNATURES};
 use crate::state::public_randomness::{
-    get_pub_rand_commit_for_height, PUB_RAND_COMMITS, PUB_RAND_VALUES,
+    get_pub_rand_commit_for_height, PUB_RAND_COMMITS,
 };
 use crate::utils::query_finality_provider;
 
@@ -180,10 +180,6 @@ pub fn handle_finality_signature(
         block_hash,
         signature,
     )?;
-
-    // The public randomness value is good, save it.
-    // TODO?: Don't save public randomness values, to save storage space (#122)
-    PUB_RAND_VALUES.save(deps.storage, (fp_btc_pk_hex, height), &pub_rand.to_vec())?;
 
     // Build the response
     let mut res: Response<BabylonMsg> = Response::new();

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -7,8 +7,6 @@ use cw_storage_plus::{Bound, Map};
 
 /// Map of public randomness commitments by fp and block height
 pub(crate) const PUB_RAND_COMMITS: Map<(&str, u64), PubRandCommit> = Map::new("pub_rand_commits");
-/// Map of public randomness values by fp and block height
-pub(crate) const PUB_RAND_VALUES: Map<(&str, u64), Vec<u8>> = Map::new("pub_rand_values");
 
 /// `PubRandCommit` is a commitment to a series of public randomness.
 /// Currently, the commitment is a root of a Merkle tree that includes a series of public randomness


### PR DESCRIPTION
The value is not used anywhere.

## Checklist
- [X] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification 