### PR TITLE
feat: refactor votes storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### State breaking
 
 * [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore: use consistent naming for state maps
+* [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Refactor votes storage.
 
 ### Improvements
 
-* [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename `hash` to `hash_hex`.
 * [#23](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/23) Clean up dependencies to cosmos-bsn-contracts.
 * [#24](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/24) Validate public randomness commitment.
 * [#25](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/25) Improve `check_fp_exist` to ensure FP is not slashed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ dependencies = [
  "eots",
  "hex",
  "k256",
+ "rand",
  "test-utils",
  "thiserror 1.0.69",
 ]
@@ -1840,6 +1841,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]

--- a/SPEC.md
+++ b/SPEC.md
@@ -556,21 +556,22 @@ This section documents the actual state storage structure used by the finality c
 
 #### 5.5.2. Finality State Storage
 
-**SIGNATURES**: Finality provider signatures by height and provider
-- Type: `Map<(u64, &str), Vec<u8>>`
-- Storage key: `"fp_sigs"`
+**FINALITY_SIGNATURES**: Finality signatures by height and provider
+- Type: `Map<(u64, &str), FinalitySigInfo>`
+- Storage key: `"finality_signatures"`
 - Key format: `(block_height, fp_pubkey_hex)`
-- Purpose: Stores EOTS signatures submitted by finality providers
+- Purpose: Stores finality signature information including signature and block hash
+- Structure:
+  ```rust
+  pub struct FinalitySigInfo {
+      pub finality_sig: Vec<u8>,  // The EOTS finality signature
+      pub block_hash: Vec<u8>,    // The block hash that the signature is for
+  }
+  ```
 
-**BLOCK_HASHES**: Block hashes by height and provider
-- Type: `Map<(u64, &str), Vec<u8>>`
-- Storage key: `"block_hashes"`
-- Key format: `(block_height, fp_pubkey_hex)`
-- Purpose: Stores block hashes that finality providers have voted for
-
-**BLOCK_VOTES**: Voting aggregation by height and block hash
+**SIGNATORIES_BY_BLOCK_HASH**: Voting aggregation by height and block hash
 - Type: `Map<(u64, &[u8]), HashSet<String>>`
-- Storage key: `"block_votes"`
+- Storage key: `"signatories_by_block_hash"`
 - Key format: `(block_height, block_hash_bytes)`
 - Purpose: Maps each (height, block_hash) combination to the set of finality provider public keys that voted for it
 
@@ -581,6 +582,12 @@ This section documents the actual state storage structure used by the finality c
 - Purpose: Stores equivocation evidence for slashed finality providers
 
 #### 5.5.3. Public Randomness Storage
+
+**PUB_RAND_VALUES**: Individual public randomness values
+- Type: `Map<(&str, u64), Vec<u8>>`
+- Storage key: `"pub_rand_values"`
+- Key format: `(fp_pubkey_hex, block_height)`
+- Purpose: Stores individual public randomness values revealed during finality signature submission
 
 **PUB_RAND_COMMITS**: Public randomness commitments
 - Type: `Map<(&str, u64), PubRandCommit>`
@@ -596,12 +603,6 @@ This section documents the actual state storage structure used by the finality c
   }
   ```
 
-**PUB_RAND_VALUES**: Individual public randomness values
-- Type: `Map<(&str, u64), Vec<u8>>`
-- Storage key: `"fp_pub_rand"`
-- Key format: `(fp_pubkey_hex, block_height)`
-- Purpose: Stores individual public randomness values revealed during finality signature submission
-
 ### 5.6. Finality contract queries
 
 The finality contract query requirements are divided into core finality
@@ -613,10 +614,17 @@ use cw_controllers::AdminResponse;
 use std::collections::HashSet;
 
 #[cw_serde]
+pub struct BlockVoterInfo {
+    pub fp_btc_pk_hex: String,
+    pub pub_rand: Vec<u8>,
+    pub finality_signature: FinalitySigInfo,
+}
+
+#[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {    
     // MUST: Core finality queries
-    #[returns(Option<HashSet<String>>)]
+    #[returns(Option<Vec<BlockVoterInfo>>)]
     BlockVoters { height: u64, hash_hex: String },
     /// `FirstPubRandCommit` returns the first public random commitment (if any) for a given FP.
     ///
@@ -649,21 +657,32 @@ BlockVoters {
 }
 ```
 
-**Return Type:** `Option<HashSet<String>>` - Set of finality provider BTC public
-keys in hex format
+**Return Type:** `Option<Vec<BlockVoterInfo>>` - List of finality providers and their signatures for the specified block
 
 **Expected Behavior:** Finality contracts MUST implement this query to return
-the set of finality providers that voted for a specific block:
+the finality providers that voted for a specific block along with their complete signature information:
 
 1. Decode hash_hex from hex string to bytes
    - IF decode fails: RETURN error
 
-2. Query block votes storage using key (height, hash_bytes)
+2. Query signatories storage using key (height, hash_bytes)
    - Access the stored set of finality provider public keys
 
-3. Return the set of finality provider BTC public keys (hex format)
+3. For each finality provider in the set:
+   - Query the FINALITY_SIGNATURES storage using key (height, fp_pubkey_hex)
+   - IF signature not found: RETURN error (state corruption)
+   - Query the PUB_RAND_VALUES storage using key (fp_pubkey_hex, height)
+   - IF public randomness not found: RETURN error (state corruption)
+   - Create BlockVoterInfo with fp_btc_pk_hex, pub_rand, and FinalitySigInfo
+
+4. Return the list of BlockVoterInfo
    - IF no votes found: RETURN `None`
-   - IF votes exist: RETURN `Some(HashSet of fp_pubkey_hex strings)`
+   - IF votes exist: RETURN `Some(Vec<BlockVoterInfo>)`
+
+WHERE BlockVoterInfo contains:
+- `fp_btc_pk_hex`: `String` - The finality provider's BTC public key in hex format
+- `pub_rand`: `Vec<u8>` - The public randomness value for the block
+- `finality_signature`: `FinalitySigInfo` - Complete signature information including public randomness, signature, and block hash
 
 #### 5.6.2. FirstPubRandCommit (MUST)
 

--- a/contracts/finality/Cargo.toml
+++ b/contracts/finality/Cargo.toml
@@ -43,3 +43,4 @@ cosmwasm-vm           = { workspace = true }
 cw-multi-test         = { workspace = true }
 
 test-utils            = { workspace = true }
+rand                  = { workspace = true }

--- a/contracts/finality/src/error.rs
+++ b/contracts/finality/src/error.rs
@@ -60,4 +60,6 @@ pub enum ContractError {
     AlreadyEnabled,
     #[error("Finality gadget is already disabled")]
     AlreadyDisabled,
+    #[error("Public randomness already exists for finality provider {0} at height {1}")]
+    PubRandAlreadyExists(String, u64),
 }

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -225,7 +225,9 @@ pub fn handle_finality_signature(
     };
     FINALITY_SIGNATURES.save(deps.storage, (height, fp_btc_pk_hex), &finality_sig)?;
 
-    // Store public randomness separately
+    // Store public randomness
+    // We expect that this will error if a public randomness has already been
+    // stored for this finality provider at this height.
     insert_pub_rand_value(deps.storage, fp_btc_pk_hex, height, pub_rand)?;
 
     // Add the fp_btc_pk_hex to the set using the helper

--- a/contracts/finality/src/lib.rs
+++ b/contracts/finality/src/lib.rs
@@ -37,3 +37,6 @@ pub fn execute(
 ) -> Result<Response<BabylonMsg>, ContractError> {
     contract::execute(deps, env, info, msg)
 }
+
+#[cfg(test)]
+pub mod testutil;

--- a/contracts/finality/src/queries.rs
+++ b/contracts/finality/src/queries.rs
@@ -34,7 +34,7 @@ pub fn query_block_voters(
             )
         })?;
     if let Some(set) = fp_pubkey_hex_set {
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(set.len());
         for fp_btc_pk_hex in set.iter() {
             let sig = FINALITY_SIGNATURES
                 .may_load(deps.storage, (height, fp_btc_pk_hex.as_str()))?

--- a/contracts/finality/src/queries.rs
+++ b/contracts/finality/src/queries.rs
@@ -1,11 +1,18 @@
 use crate::error::ContractError;
 use crate::state::config::{Config, ADMIN, CONFIG, IS_ENABLED};
-use crate::state::finality::BLOCK_VOTES;
-use crate::state::public_randomness::get_pub_rand_commit;
+use crate::state::finality::{FinalitySigInfo, FINALITY_SIGNATURES, SIGNATORIES_BY_BLOCK_HASH};
 use crate::state::public_randomness::PubRandCommit;
+use crate::state::public_randomness::{get_pub_rand_commit, PUB_RAND_VALUES};
+use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Deps, StdResult, Storage};
 use cw_controllers::AdminResponse;
-use std::collections::HashSet;
+
+#[cw_serde]
+pub struct BlockVoterInfo {
+    pub fp_btc_pk_hex: String,
+    pub pub_rand: Vec<u8>,
+    pub finality_signature: FinalitySigInfo,
+}
 
 pub fn query_config(deps: Deps) -> StdResult<Config> {
     CONFIG.load(deps.storage)
@@ -15,10 +22,9 @@ pub fn query_block_voters(
     deps: Deps,
     height: u64,
     hash_hex: String,
-) -> Result<Option<HashSet<String>>, ContractError> {
+) -> Result<Option<Vec<BlockVoterInfo>>, ContractError> {
     let block_hash_bytes: Vec<u8> = hex::decode(&hash_hex).map_err(ContractError::HexError)?;
-    // find all FPs that voted for this (height, hash_hex) combination
-    let fp_pubkey_hex_list = BLOCK_VOTES
+    let fp_pubkey_hex_set = SIGNATORIES_BY_BLOCK_HASH
         .may_load(deps.storage, (height, &block_hash_bytes))
         .map_err(|e| {
             ContractError::QueryBlockVoterError(
@@ -27,7 +33,39 @@ pub fn query_block_voters(
                 format!("Original error: {:?}", e),
             )
         })?;
-    Ok(fp_pubkey_hex_list)
+    if let Some(set) = fp_pubkey_hex_set {
+        let mut result = Vec::new();
+        for fp_btc_pk_hex in set.iter() {
+            let sig = FINALITY_SIGNATURES
+                .may_load(deps.storage, (height, fp_btc_pk_hex.as_str()))?
+                .ok_or_else(|| {
+                    ContractError::QueryBlockVoterError(
+                        height,
+                        hash_hex.clone(),
+                        format!("Missing FinalitySigInfo for FP {}", fp_btc_pk_hex),
+                    )
+                })?;
+
+            let pub_rand = PUB_RAND_VALUES
+                .may_load(deps.storage, (fp_btc_pk_hex.as_str(), height))?
+                .ok_or_else(|| {
+                    ContractError::QueryBlockVoterError(
+                        height,
+                        hash_hex.clone(),
+                        format!("Missing public randomness for FP {}", fp_btc_pk_hex),
+                    )
+                })?;
+
+            result.push(BlockVoterInfo {
+                fp_btc_pk_hex: fp_btc_pk_hex.clone(),
+                pub_rand,
+                finality_signature: sig,
+            });
+        }
+        Ok(Some(result))
+    } else {
+        Ok(None)
+    }
 }
 
 pub fn query_first_pub_rand_commit(
@@ -52,4 +90,63 @@ pub fn query_is_enabled(deps: Deps) -> StdResult<bool> {
 
 pub fn query_admin(deps: Deps) -> StdResult<AdminResponse> {
     ADMIN.query_admin(deps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::finality::{FinalitySigInfo, FINALITY_SIGNATURES, SIGNATORIES_BY_BLOCK_HASH};
+    use crate::state::public_randomness::PUB_RAND_VALUES;
+    use crate::testutil::datagen::*;
+    use cosmwasm_std::testing::mock_dependencies;
+    use rand::{thread_rng, Rng};
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_query_block_voters_returns_fp_and_signature() {
+        let mut deps = mock_dependencies();
+        let height = 42u64;
+        let block_hash: Vec<u8> = get_random_block_hash();
+        let block_hash_hex = hex::encode(&block_hash);
+        let mut rng = thread_rng();
+        let num_fps = rng.gen_range(1..=10);
+        let mut set = HashSet::new();
+        let mut expected: Vec<(String, Vec<u8>, FinalitySigInfo)> = Vec::new();
+        for _ in 0..num_fps {
+            let fp_btc_pk_hex = get_random_fp_pk_hex();
+            let sig = get_random_finality_sig(&block_hash);
+            let pub_rand = get_random_pub_rand();
+            set.insert(fp_btc_pk_hex.clone());
+            FINALITY_SIGNATURES
+                .save(
+                    deps.as_mut().storage,
+                    (height, fp_btc_pk_hex.as_str()),
+                    &sig,
+                )
+                .unwrap();
+            PUB_RAND_VALUES
+                .save(
+                    deps.as_mut().storage,
+                    (fp_btc_pk_hex.as_str(), height),
+                    &pub_rand,
+                )
+                .unwrap();
+            expected.push((fp_btc_pk_hex, pub_rand, sig));
+        }
+        SIGNATORIES_BY_BLOCK_HASH
+            .save(deps.as_mut().storage, (height, &block_hash), &set)
+            .unwrap();
+        let result = query_block_voters(deps.as_ref(), height, block_hash_hex).unwrap();
+        let voters = result.expect("should have voters");
+        assert_eq!(voters.len(), num_fps);
+        // Check all expected FPs and signatures are present
+        for (fp, pub_rand, sig) in expected {
+            let found = voters.iter().find(|v| v.fp_btc_pk_hex == fp);
+            assert!(found.is_some(), "FP {} not found in voters", fp);
+            let found = found.unwrap();
+            assert_eq!(found.pub_rand, pub_rand);
+            assert_eq!(found.finality_signature.finality_sig, sig.finality_sig);
+            assert_eq!(found.finality_signature.block_hash, sig.block_hash);
+        }
+    }
 }

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -6,6 +6,18 @@ use std::collections::HashSet;
 
 use crate::state::Bytes;
 
+/// Map of (block height, block hash) tuples to the finality signature for that block.
+pub(crate) const FINALITY_SIGNATURES: Map<(u64, &str), FinalitySigInfo> =
+    Map::new("finality_signatures");
+
+/// Map of (block height, block hash) tuples to the list of signatories
+/// for that block.
+pub(crate) const SIGNATORIES_BY_BLOCK_HASH: Map<(u64, &[u8]), HashSet<String>> =
+    Map::new("signatories_by_block_hash");
+
+/// Map of evidence by block height and fp
+pub(crate) const EVIDENCES: Map<(u64, &str), Evidence> = Map::new("evidences");
+
 /// Evidence is the evidence that a finality provider has signed finality
 /// signatures with correct public randomness on two conflicting Babylon headers
 #[cw_serde]
@@ -33,27 +45,15 @@ pub struct Evidence {
     pub fork_finality_sig: Bytes,
 }
 
+/// FinalitySigInfo is a struct that contains the finality signature and
+/// block hash for a given block height and fp
 #[cw_serde]
-// FinalitySigInfo is a struct that contains the finality signature and
-// block hash for a given block height and fp
 pub struct FinalitySigInfo {
-    // the finality signature
+    /// the finality signature
     pub finality_sig: Vec<u8>,
-    // the block hash that the finality signature is for
+    /// the block hash that the finality signature is for
     pub block_hash: Vec<u8>,
 }
-
-/// Map of (block height, block hash) tuples to the finality signature for that block.
-pub(crate) const FINALITY_SIGNATURES: Map<(u64, &str), FinalitySigInfo> =
-    Map::new("finality_signatures");
-
-/// Map of (block height, block hash) tuples to the list of signatories
-/// for that block.
-pub(crate) const SIGNATORIES_BY_BLOCK_HASH: Map<(u64, &[u8]), HashSet<String>> =
-    Map::new("signatories_by_block_hash");
-
-/// Map of evidence by block height and fp
-pub(crate) const EVIDENCES: Map<(u64, &str), Evidence> = Map::new("evidences");
 
 /// Inserts a signatory into the SIGNATORIES_BY_BLOCK_HASH map for the given height and block hash.
 /// The function does not do any checks:

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -1,4 +1,6 @@
+use crate::error::ContractError;
 use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Storage;
 use cw_storage_plus::Map;
 use std::collections::HashSet;
 
@@ -31,14 +33,71 @@ pub struct Evidence {
     pub fork_finality_sig: Bytes,
 }
 
-/// Map of signatures by block height and fp
-pub(crate) const SIGNATURES: Map<(u64, &str), Vec<u8>> = Map::new("signatures");
+#[cw_serde]
+// FinalitySigInfo is a struct that contains the finality signature and
+// block hash for a given block height and fp
+pub struct FinalitySigInfo {
+    // the finality signature
+    pub finality_sig: Vec<u8>,
+    // the block hash that the finality signature is for
+    pub block_hash: Vec<u8>,
+}
 
-/// Map of block hashes by block height and fp
-pub(crate) const BLOCK_HASHES: Map<(u64, &str), Vec<u8>> = Map::new("block_hashes");
+/// Map of (block height, block hash) tuples to the finality signature for that block.
+pub(crate) const FINALITY_SIGNATURES: Map<(u64, &str), FinalitySigInfo> =
+    Map::new("finality_signatures");
 
-/// Map of (block height, block hash) tuples to the list of BTC PKs (in hex) of finality providers that voted for this combination
-pub(crate) const BLOCK_VOTES: Map<(u64, &[u8]), HashSet<String>> = Map::new("block_votes");
+/// Map of (block height, block hash) tuples to the list of signatories
+/// for that block.
+pub(crate) const SIGNATORIES_BY_BLOCK_HASH: Map<(u64, &[u8]), HashSet<String>> =
+    Map::new("signatories_by_block_hash");
 
 /// Map of evidence by block height and fp
 pub(crate) const EVIDENCES: Map<(u64, &str), Evidence> = Map::new("evidences");
+
+/// Inserts a signatory into the SIGNATORIES_BY_BLOCK_HASH map for the given height and block hash.
+pub fn insert_signatory(
+    storage: &mut dyn Storage,
+    height: u64,
+    block_hash: &[u8],
+    signatory: &str,
+) -> Result<(), ContractError> {
+    let mut set = SIGNATORIES_BY_BLOCK_HASH
+        .may_load(storage, (height, block_hash))?
+        .unwrap_or_else(HashSet::new);
+    set.insert(signatory.to_string());
+    SIGNATORIES_BY_BLOCK_HASH.save(storage, (height, block_hash), &set)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::datagen::*;
+    use cosmwasm_std::testing::mock_dependencies;
+    use rand::{thread_rng, Rng};
+
+    #[test]
+    fn test_insert_signatory_adds_to_set() {
+        let mut deps = mock_dependencies();
+        let height = thread_rng().gen_range(1..1000);
+        let block_hash = get_random_block_hash();
+        let num_signatories = thread_rng().gen_range(1..=20);
+        let mut signatories_set = std::collections::HashSet::new();
+        while signatories_set.len() < num_signatories {
+            signatories_set.insert(get_random_fp_pk_hex());
+        }
+        let signatories: Vec<_> = signatories_set.into_iter().collect();
+        for signatory in &signatories {
+            insert_signatory(deps.as_mut().storage, height, &block_hash, signatory).unwrap();
+        }
+        // Check that all signatories are present
+        let set = SIGNATORIES_BY_BLOCK_HASH
+            .load(deps.as_ref().storage, (height, &block_hash))
+            .unwrap();
+        for signatory in &signatories {
+            assert!(set.contains(signatory));
+        }
+        assert_eq!(set.len(), num_signatories);
+    }
+}

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -56,6 +56,12 @@ pub(crate) const SIGNATORIES_BY_BLOCK_HASH: Map<(u64, &[u8]), HashSet<String>> =
 pub(crate) const EVIDENCES: Map<(u64, &str), Evidence> = Map::new("evidences");
 
 /// Inserts a signatory into the SIGNATORIES_BY_BLOCK_HASH map for the given height and block hash.
+/// The function does not do any checks:
+/// - If the signatory is already there, the set will remain the same.
+/// - If the signatory is a new one, the caller is responsible for ensuring that they are
+///   inserting the right one. An insertion without a corresponding entry for a finality provider
+///   in the FINALITY_SIGNATURES or PUB_RAND_VALUES storage might point to a storage corruption.
+///   TODO: Should we have checks to avoid the above storage corruption situation?
 pub fn insert_signatory(
     storage: &mut dyn Storage,
     height: u64,

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -82,6 +82,7 @@ mod tests {
     use crate::testutil::datagen::*;
     use cosmwasm_std::testing::mock_dependencies;
     use rand::{thread_rng, Rng};
+    use std::collections::HashSet;
 
     #[test]
     fn test_insert_signatory_adds_to_set() {
@@ -89,7 +90,7 @@ mod tests {
         let height = thread_rng().gen_range(1..1000);
         let block_hash = get_random_block_hash();
         let num_signatories = thread_rng().gen_range(1..=20);
-        let mut signatories_set = std::collections::HashSet::new();
+        let mut signatories_set = HashSet::new();
         while signatories_set.len() < num_signatories {
             signatories_set.insert(get_random_fp_pk_hex());
         }

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -11,7 +11,7 @@ pub(crate) const FINALITY_SIGNATURES: Map<(u64, &str), FinalitySigInfo> =
     Map::new("finality_signatures");
 
 /// Map of (block height, block hash) tuples to the list of signatories
-/// for that block.
+/// (each identified by the BTC public key in hex) for that block.
 pub(crate) const SIGNATORIES_BY_BLOCK_HASH: Map<(u64, &[u8]), HashSet<String>> =
     Map::new("signatories_by_block_hash");
 

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -107,7 +107,9 @@ pub fn get_pub_rand_commit(
 ///
 /// - If no value exists, it inserts the value.
 /// - If the same value already exists, it is a no-op and returns Ok(())
-/// - If a different value exists, it returns ContractError::PubRandAlreadyExists
+/// - If a different value exists, it returns ContractError::PubRandAlreadyExists.
+///   This is an error as the contract should recognize only a single public randomness value
+///   for a specific height per finality provider.
 pub fn insert_pub_rand_value(
     storage: &mut dyn Storage,
     fp_btc_pk_hex: &str,

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -5,10 +5,11 @@ use cosmwasm_std::Order::{Ascending, Descending};
 use cosmwasm_std::{StdResult, Storage};
 use cw_storage_plus::{Bound, Map};
 
+/// Map of public randomness values by fp public key hex and block height
+pub(crate) const PUB_RAND_VALUES: Map<(&str, u64), Vec<u8>> = Map::new("pub_rand_values");
+
 /// Map of public randomness commitments by fp and block height
 pub(crate) const PUB_RAND_COMMITS: Map<(&str, u64), PubRandCommit> = Map::new("pub_rand_commits");
-/// Map of public randomness values by fp and block height
-pub(crate) const PUB_RAND_VALUES: Map<(&str, u64), Vec<u8>> = Map::new("pub_rand_values");
 
 /// `PubRandCommit` is a commitment to a series of public randomness.
 /// Currently, the commitment is a root of a Merkle tree that includes a series of public randomness
@@ -100,4 +101,97 @@ pub fn get_pub_rand_commit(
 
     // Return the results or an empty vector if no results found
     Ok(res)
+}
+
+/// Inserts a public randomness value into the PUB_RAND_VALUES map for the given fp and height.
+///
+/// - If no value exists, it inserts the value.
+/// - If the same value already exists, it is a no-op and returns Ok(())
+/// - If a different value exists, it returns ContractError::PubRandAlreadyExists
+pub fn insert_pub_rand_value(
+    storage: &mut dyn Storage,
+    fp_btc_pk_hex: &str,
+    height: u64,
+    pub_rand: &[u8],
+) -> Result<(), ContractError> {
+    if let Some(existing) = PUB_RAND_VALUES.may_load(storage, (fp_btc_pk_hex, height))? {
+        if existing == pub_rand {
+            return Ok(());
+        } else {
+            return Err(ContractError::PubRandAlreadyExists(
+                fp_btc_pk_hex.to_string(),
+                height,
+            ));
+        }
+    }
+    PUB_RAND_VALUES.save(storage, (fp_btc_pk_hex, height), &pub_rand.to_vec())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::datagen::*;
+    use cosmwasm_std::testing::mock_dependencies;
+    use rand::{thread_rng, Rng};
+
+    #[test]
+    fn test_insert_pub_rand_value() {
+        let mut deps = mock_dependencies();
+        let fp_btc_pk_hex = get_random_fp_pk_hex();
+        let num_sets = thread_rng().gen_range(1..=5);
+        let mut all_heights = std::collections::HashSet::new();
+        let mut pub_rands = Vec::new();
+        let mut last_height = 0u64;
+        for _ in 0..num_sets {
+            let set_len = thread_rng().gen_range(1..=10);
+            // Ensure a gap of at least 1 between sets
+            let start_height = last_height + thread_rng().gen_range(1..=5);
+            let heights: Vec<u64> = (start_height..start_height + set_len).collect();
+            for &height in &heights {
+                assert!(!all_heights.contains(&height), "Height overlap detected");
+                all_heights.insert(height);
+                let pub_rand = get_random_pub_rand();
+                insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk_hex, height, &pub_rand)
+                    .unwrap();
+                pub_rands.push((height, pub_rand.clone()));
+            }
+            last_height = *heights.last().unwrap();
+        }
+        // Check that all pub_rand values are present
+        for (height, pub_rand) in &pub_rands {
+            let stored = PUB_RAND_VALUES
+                .load(deps.as_ref().storage, (&fp_btc_pk_hex, *height))
+                .unwrap();
+            assert_eq!(stored, *pub_rand);
+            // Try to insert the same value again and expect Ok(())
+            assert!(insert_pub_rand_value(
+                deps.as_mut().storage,
+                &fp_btc_pk_hex,
+                *height,
+                pub_rand
+            )
+            .is_ok());
+            // Try to insert a different value and expect an error
+            let mut different_pub_rand = get_random_pub_rand();
+            // Ensure it's different
+            while different_pub_rand == *pub_rand {
+                different_pub_rand = get_random_pub_rand();
+            }
+            let err = insert_pub_rand_value(
+                deps.as_mut().storage,
+                &fp_btc_pk_hex,
+                *height,
+                &different_pub_rand,
+            )
+            .unwrap_err();
+            match err {
+                ContractError::PubRandAlreadyExists(ref pk, h) => {
+                    assert_eq!(pk, &fp_btc_pk_hex);
+                    assert_eq!(h, *height);
+                }
+                _ => panic!("Expected PubRandAlreadyExists error, got {:?}", err),
+            }
+        }
+    }
 }

--- a/contracts/finality/src/testutil/datagen.rs
+++ b/contracts/finality/src/testutil/datagen.rs
@@ -1,0 +1,26 @@
+use crate::state::finality::FinalitySigInfo;
+use rand::{thread_rng, Rng};
+
+pub fn get_random_block_hash() -> Vec<u8> {
+    let mut rng = thread_rng();
+    (0..32).map(|_| rng.gen()).collect()
+}
+
+pub fn get_random_fp_pk_hex() -> String {
+    let mut rng = thread_rng();
+    let bytes: Vec<u8> = (0..33).map(|_| rng.gen()).collect();
+    hex::encode(bytes)
+}
+
+pub fn get_random_pub_rand() -> Vec<u8> {
+    let mut rng = thread_rng();
+    (0..32).map(|_| rng.gen()).collect()
+}
+
+pub fn get_random_finality_sig(block_hash: &[u8]) -> FinalitySigInfo {
+    let mut rng = rand::thread_rng();
+    FinalitySigInfo {
+        finality_sig: (0..64).map(|_| rng.gen()).collect(),
+        block_hash: block_hash.to_vec(),
+    }
+}

--- a/contracts/finality/src/testutil/mod.rs
+++ b/contracts/finality/src/testutil/mod.rs
@@ -1,0 +1,1 @@
+pub mod datagen;


### PR DESCRIPTION
The pull request does the following:
* Combines block hashes and signatures from them into a single storage instead of separate.
* Introduces getters/setters for * some * state items and unit tests for them.
* Introduces a query for retrieving all signatories for a block hash, along with the finality votes they have submitted and randomness.

## Checklist
- [X] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification 