### PR TITLE
finality: refactor handle_finality_signature and add unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#48](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/48) finality: refactor handle_finality_signature and revise unit tests
 * [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename `hash` to `hash_hex`.
 * [#42](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/42) test: Add unit tests for public randomness commitment validation.
 * [#47](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/47) Create state/evidence.rs file and define setters/getters.

--- a/contracts/finality/src/error.rs
+++ b/contracts/finality/src/error.rs
@@ -64,4 +64,6 @@ pub enum ContractError {
     PubRandAlreadyExists(String, u64),
     #[error("Evidence already exists for finality provider {0} at height {1}")]
     EvidenceAlreadyExists(String, u64),
+    #[error("Duplicate signatory {0}")]
+    DuplicateSignatory(String),
 }

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::Storage;
 use cw_storage_plus::Map;
 use std::collections::HashSet;
 
-/// Map of (block height, block hash) tuples to the finality signature for that block.
+/// Map of (block height, finality provider public key in hex) tuples to the finality signature for that block.
 pub(crate) const FINALITY_SIGNATURES: Map<(u64, &str), FinalitySigInfo> =
     Map::new("finality_signatures");
 
@@ -25,12 +25,10 @@ pub struct FinalitySigInfo {
 
 /// Inserts a signatory into the SIGNATORIES_BY_BLOCK_HASH map for the given height and block hash.
 /// The function does not do any checks:
-/// - If the signatory is already there, the set will remain the same.
+/// - If the signatory is already there, return an error.
 /// - If the signatory is a new one, the caller is responsible for ensuring that they are
 ///   inserting the right one. An insertion without a corresponding entry for a finality provider
-///   in the FINALITY_SIGNATURES or PUB_RAND_VALUES storage might point to a storage corruption.
-///   TODO: Should we have checks to avoid the above storage corruption situation?
-pub fn insert_signatory(
+fn insert_signatory(
     storage: &mut dyn Storage,
     height: u64,
     block_hash: &[u8],
@@ -39,8 +37,38 @@ pub fn insert_signatory(
     let mut set = SIGNATORIES_BY_BLOCK_HASH
         .may_load(storage, (height, block_hash))?
         .unwrap_or_else(HashSet::new);
-    set.insert(signatory.to_string());
+    if !set.insert(signatory.to_string()) {
+        return Err(ContractError::DuplicateSignatory(signatory.to_string()));
+    }
     SIGNATORIES_BY_BLOCK_HASH.save(storage, (height, block_hash), &set)?;
+    Ok(())
+}
+
+/// Inserts finality sig and signatory into storage.
+/// Returns an error if any of the operations fail.
+pub fn insert_finality_sig_and_signatory(
+    storage: &mut dyn Storage,
+    fp_btc_pk_hex: &str,
+    height: u64,
+    block_hash: &[u8],
+    signature: &[u8],
+) -> Result<(), ContractError> {
+    // Save the finality signature
+    // TODO: in the case of an existing finality signature,
+    // we are overriding the existing finality signature.
+    // https://github.com/babylonlabs-io/rollup-bsn-contracts/issues/44
+    FINALITY_SIGNATURES.save(
+        storage,
+        (height, fp_btc_pk_hex),
+        &FinalitySigInfo {
+            finality_sig: signature.to_vec(),
+            block_hash: block_hash.to_vec(),
+        },
+    )?;
+
+    // Add the fp_btc_pk_hex to the signatories for the (height, block_hash) pair
+    insert_signatory(storage, height, block_hash, fp_btc_pk_hex)?;
+
     Ok(())
 }
 
@@ -49,30 +77,72 @@ mod tests {
     use super::*;
     use crate::testutil::datagen::*;
     use cosmwasm_std::testing::mock_dependencies;
-    use rand::{rng, Rng};
-    use std::collections::HashSet;
 
     #[test]
-    fn test_insert_signatory_adds_to_set() {
+    fn test_insert_finality_sig_and_signatory() {
         let mut deps = mock_dependencies();
         let height = get_random_u64();
         let block_hash = get_random_block_hash();
-        let num_signatories = rng().random_range(1..=20);
-        let mut signatories_set = HashSet::new();
-        while signatories_set.len() < num_signatories {
-            signatories_set.insert(get_random_fp_pk_hex());
-        }
-        let signatories: Vec<_> = signatories_set.into_iter().collect();
-        for signatory in &signatories {
-            insert_signatory(deps.as_mut().storage, height, &block_hash, signatory).unwrap();
-        }
-        // Check that all signatories are present
-        let set = SIGNATORIES_BY_BLOCK_HASH
+        let signature = get_random_block_hash();
+        let fp_btc_pk_hex = get_random_fp_pk_hex();
+
+        // Insert the data
+        insert_finality_sig_and_signatory(
+            deps.as_mut().storage,
+            &fp_btc_pk_hex,
+            height,
+            &block_hash,
+            &signature,
+        )
+        .unwrap();
+
+        // Verify finality signature was stored correctly
+        let finality_sig_info = FINALITY_SIGNATURES
+            .load(deps.as_ref().storage, (height, &fp_btc_pk_hex))
+            .unwrap();
+        assert_eq!(finality_sig_info.finality_sig, signature);
+        assert_eq!(finality_sig_info.block_hash, block_hash);
+
+        // Verify signatory was added to the set
+        let signatories = SIGNATORIES_BY_BLOCK_HASH
             .load(deps.as_ref().storage, (height, &block_hash))
             .unwrap();
-        for signatory in &signatories {
-            assert!(set.contains(signatory));
-        }
-        assert_eq!(set.len(), num_signatories);
+        assert!(signatories.contains(&fp_btc_pk_hex));
+        assert_eq!(signatories.len(), 1);
+
+        // Test case 1 (should fail): duplicate signatory for the same block
+        let result = insert_signatory(deps.as_mut().storage, height, &block_hash, &fp_btc_pk_hex);
+        assert_eq!(
+            result,
+            Err(ContractError::DuplicateSignatory(fp_btc_pk_hex.clone()))
+        );
+
+        // Test case 2 (should succeed): signing a different block hash at the same height
+        let different_block_hash = get_random_block_hash();
+        let different_signature = get_random_block_hash();
+        let result = insert_finality_sig_and_signatory(
+            deps.as_mut().storage,
+            &fp_btc_pk_hex,
+            height,
+            &different_block_hash,
+            &different_signature,
+        );
+
+        // This should succeed
+        assert!(result.is_ok());
+
+        // Verify the new finality signature was stored correctly
+        let finality_sig_info = FINALITY_SIGNATURES
+            .load(deps.as_ref().storage, (height, &fp_btc_pk_hex))
+            .unwrap();
+        assert_eq!(finality_sig_info.finality_sig, different_signature);
+        assert_eq!(finality_sig_info.block_hash, different_block_hash);
+
+        // Verify signatory was added to the set for the new block hash
+        let signatories = SIGNATORIES_BY_BLOCK_HASH
+            .load(deps.as_ref().storage, (height, &different_block_hash))
+            .unwrap();
+        assert!(signatories.contains(&fp_btc_pk_hex));
+        assert_eq!(signatories.len(), 1);
     }
 }

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{StdResult, Storage};
 use cw_storage_plus::{Bound, Map};
 
 /// Map of public randomness values by fp public key hex and block height
-pub(crate) const PUB_RAND_VALUES: Map<(&str, u64), Vec<u8>> = Map::new("pub_rand_values");
+pub const PUB_RAND_VALUES: Map<(&str, u64), Vec<u8>> = Map::new("pub_rand_values");
 
 /// Map of public randomness commitments by fp and block height
 const PUB_RAND_COMMITS: Map<(&str, u64), PubRandCommit> = Map::new("pub_rand_commits");
@@ -164,7 +164,7 @@ pub fn insert_pub_rand_commit(
 /// - If a different value exists, it returns ContractError::PubRandAlreadyExists.
 ///   This is an error as the contract should recognize only a single public randomness value
 ///   for a specific height per finality provider.
-pub fn insert_pub_rand_value(
+pub(crate) fn insert_pub_rand_value(
     storage: &mut dyn Storage,
     fp_btc_pk_hex: &str,
     height: u64,

--- a/contracts/finality/src/testutil/datagen.rs
+++ b/contracts/finality/src/testutil/datagen.rs
@@ -1,4 +1,4 @@
-use crate::state::finality::FinalitySigInfo;
+use crate::state::{evidence::Evidence, finality::FinalitySigInfo};
 use rand::{rng, Rng};
 
 pub fn get_random_u64() -> u64 {
@@ -11,10 +11,13 @@ pub fn get_random_block_hash() -> Vec<u8> {
     (0..32).map(|_| rng.random()).collect()
 }
 
-pub fn get_random_fp_pk_hex() -> String {
+pub fn get_random_fp_pk() -> Vec<u8> {
     let mut rng = rng();
-    let bytes: Vec<u8> = (0..33).map(|_| rng.random()).collect();
-    hex::encode(bytes)
+    (0..33).map(|_| rng.random()).collect()
+}
+
+pub fn get_random_fp_pk_hex() -> String {
+    hex::encode(get_random_fp_pk())
 }
 
 pub fn get_random_pub_rand() -> Vec<u8> {
@@ -27,5 +30,20 @@ pub fn get_random_finality_sig(block_hash: &[u8]) -> FinalitySigInfo {
     FinalitySigInfo {
         finality_sig: (0..64).map(|_| rng.random()).collect(),
         block_hash: block_hash.to_vec(),
+    }
+}
+
+/// Get a random evidence for a given height and finality provider.
+/// We are adding it here instead of datagen.rs as it is only used here.
+/// NOTE: The result is a mocked result, the signatures are not valid.
+pub fn get_random_evidence(height: u64, fp_btc_pk_hex: &str) -> Evidence {
+    Evidence {
+        fp_btc_pk: hex::decode(fp_btc_pk_hex).unwrap(),
+        block_height: height,
+        pub_rand: get_random_pub_rand(),
+        canonical_app_hash: get_random_block_hash(),
+        fork_app_hash: get_random_block_hash(),
+        canonical_finality_sig: (0..64).map(|_| rand::random()).collect(),
+        fork_finality_sig: (0..64).map(|_| rand::random()).collect(),
     }
 }


### PR DESCRIPTION
## Description
<!-- Brief description of changes -->

Resolves #33
Resolves #36

This PR

- introduces DB handler for inserting finality sig and signatory in an atomic function
- tightens DB access functions by making a bunch of functions private
- adds unit tests for inserting finality sig and signatory
- refactors `handle_finality_signature` to 
  - use the DB handler
  - make it explicit that equivocating finality signatures are also stored in DB
- removes various comments and TODOs that are no longer relevant

## Checklist
- [ ] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification 