### PR TITLE
feat: Data pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State breaking
 
+* [#73](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/73) feat: add unified data pruning handler for finality signatures and public randomness values
 * [#55](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/55) evidence: remove evidence DB
 * [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore: use consistent naming for state maps
 * [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Refactor votes storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State breaking
 
-* [#73](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/73) feat: add unified data pruning handler for finality signatures and public randomness values
+* [#73](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/73) Add data pruning handler for finality signatures, signatories and public randomness values
 * [#55](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/55) evidence: remove evidence DB
 * [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore: use consistent naming for state maps
 * [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Refactor votes storage.

--- a/PRUNING.md
+++ b/PRUNING.md
@@ -1,0 +1,220 @@
+# Data Pruning Guidelines
+
+This document provides guidelines for contract administrators on how to use the data pruning functionality in the Rollup BSN finality contract.
+
+## Overview
+
+The BSN finality contract stores three types of data that can grow indefinitely over time:
+
+1. **Finality Signatures** - Cryptographic signatures from finality providers for each finalized block.
+2. **Signatories by Block Hash** - Records of which finality providers signed each block.
+3. **Public Randomness Values** - Pre-committed randomness values used in finality signatures.
+
+To prevent unlimited storage growth and manage gas costs, the contract provides a unified pruning mechanism that allows administrators to remove old data safely.
+
+## When to Prune
+
+### Pruning Triggers
+
+Consider pruning when:
+
+- **Storage Growth**: The contract's storage size is approaching limits or causing high gas costs.
+- **Performance Degradation**: Query operations are becoming slow due to large datasets.
+- **Operational Maintenance**: Regular maintenance to keep the contract efficient.
+- **Cost Management**: Reducing ongoing storage costs on the blockchain.
+
+### Safety Considerations
+
+**CRITICAL**: Pruning is irreversible. Once data is pruned, it cannot be recovered. Consider these factors before pruning:
+
+1. **Chain Reorganization Safety**: Ensure the pruning height provides sufficient safety margin for potential chain reorganizations.
+2. **Data Submission Delays**: Account for delays in finality signature submissions.
+3. **Dispute Periods**: Consider any dispute or challenge periods that might require historical data.
+4. **Audit Requirements**: Ensure compliance with any audit or regulatory requirements.
+
+### Recommended Pruning Height
+
+A conservative approach is to prune data that is:
+- **At least 1000 blocks old** from the current rollup height.
+- **Beyond any reasonable chain reorganization depth** (typically 100-500 blocks).
+- **After any dispute periods** have expired.
+
+## How to Prune
+
+### Pruning Message
+
+Use the `PruneData` message with the following parameters:
+
+```json
+{
+  "prune_data": {
+    "rollup_height": 10000,
+    "max_signatures_to_prune": 50,
+    "max_pub_rand_values_to_prune": 50
+  }
+}
+```
+
+### Parameters
+
+- **`rollup_height`** (required): Remove all data for rollup blocks with height ≤ this value.
+- **`max_signatures_to_prune`** (optional): Maximum number of finality signatures and signatories to prune in one operation.
+  - Default: 50
+  - Use `Some(0)` to disable pruning of signatures/signatories for this call
+  - Maximum: 100
+- **`max_pub_rand_values_to_prune`** (optional): Maximum number of public randomness values to prune in one operation.
+  - Default: 50
+  - Use `Some(0)` to disable pruning of public randomness values for this call
+  - Maximum: 100
+
+### Pruning Strategy
+
+#### Incremental Pruning
+
+For large datasets, use incremental pruning to avoid gas limits:
+
+1. **Start with smaller limits**: Use `max_signatures_to_prune: 25` and `max_pub_rand_values_to_prune: 25`.
+2. **Monitor gas usage**: Check transaction gas consumption.
+3. **Increase gradually**: If gas usage is acceptable, increase limits.
+4. **Repeat until complete**: Continue until all desired data is pruned.
+
+#### Selective Pruning
+
+You can selectively prune different data types:
+
+- **Signatures only**: Set `max_pub_rand_values_to_prune: Some(0)`.
+- **Public randomness only**: Set `max_signatures_to_prune: Some(0)`.
+- **All data**: Provide both parameters (or use defaults).
+
+## Pruning Frequency
+
+### Recommended Schedule
+
+- **Weekly**: For active networks with high transaction volume.
+- **Monthly**: For moderate activity networks.
+- **Quarterly**: For low activity networks.
+- **On-demand**: When storage costs become significant.
+
+### Monitoring
+
+Monitor these metrics to determine pruning frequency:
+
+1. **Storage Size**: Track contract storage growth over time.
+2. **Gas Costs**: Monitor transaction costs for queries and operations.
+3. **Performance**: Track query response times.
+4. **Data Age**: Monitor the age of oldest stored data.
+
+## Example Pruning Scenarios
+
+### Scenario 1: Regular Maintenance
+
+**Goal**: Keep storage manageable with weekly pruning.
+
+```json
+{
+  "prune_data": {
+    "rollup_height": "current_height - 1000",
+    "max_signatures_to_prune": 50,
+    "max_pub_rand_values_to_prune": 50
+  }
+}
+```
+
+### Scenario 2: Large Dataset Cleanup
+
+**Goal**: Clean up a large backlog of old data.
+
+**Step 1**: Start with conservative limits
+```json
+{
+  "prune_data": {
+    "rollup_height": "current_height - 2000",
+    "max_signatures_to_prune": 25,
+    "max_pub_rand_values_to_prune": 25
+  }
+}
+```
+
+**Step 2**: Increase limits if gas usage is acceptable
+```json
+{
+  "prune_data": {
+    "rollup_height": "current_height - 2000",
+    "max_signatures_to_prune": 75,
+    "max_pub_rand_values_to_prune": 75
+  }
+}
+```
+
+### Scenario 3: Emergency Storage Management
+
+**Goal**: Quickly reduce storage when approaching limits
+
+```json
+{
+  "prune_data": {
+    "rollup_height": "current_height - 500",
+    "max_signatures_to_prune": 100,
+    "max_pub_rand_values_to_prune": 100
+  }
+}
+```
+
+## Best Practices
+
+### Before Pruning
+
+1. **Backup**: Ensure you have off-chain backups of critical data.
+2. **Verify**: Double-check the pruning height is safe.
+3. **Test**: Test pruning on a testnet if available.
+4. **Notify**: Inform stakeholders about planned maintenance.
+
+### During Pruning
+
+1. **Monitor**: Watch transaction execution and gas usage.
+2. **Log**: Keep records of pruning operations.
+3. **Verify**: Confirm data was pruned as expected.
+4. **Document**: Record the pruning height and results.
+
+### After Pruning
+
+1. **Validate**: Verify contract state is correct.
+2. **Monitor**: Watch for any unexpected behavior.
+3. **Update**: Update operational procedures if needed.
+4. **Schedule**: Plan the next pruning operation.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Gas Limit Exceeded**: Reduce `max_signatures_to_prune` or `max_pub_rand_values_to_prune`.
+2. **No Data Pruned**: Check if `rollup_height` is too low.
+3. **Partial Pruning**: Some data types may have different age distributions.
+
+### Error Handling
+
+- **Unauthorized**: Ensure you're using the admin account.
+- **Invalid Parameters**: Check parameter values and types.
+- **Storage Errors**: Verify contract has sufficient gas for the operation.
+
+## Monitoring and Alerts
+
+### Key Metrics to Track
+
+1. **Storage Growth Rate**: Bytes per block or per day.
+2. **Oldest Data Age**: Age of oldest stored data.
+3. **Pruning Frequency**: Time between pruning operations.
+4. **Gas Costs**: Average gas cost for queries and operations.
+
+### Recommended Alerts
+
+- Storage size approaching 80% of limits.
+- Oldest data older than 30 days.
+- Gas costs exceeding normal thresholds.
+- Failed pruning operations.
+
+## Conclusion
+
+Data pruning is a critical operational task for maintaining the efficiency and cost-effectiveness of the BSN finality contract. By following these guidelines and maintaining a regular pruning schedule, administrators can ensure the contract remains performant and cost-effective while preserving the safety and integrity of the system.
+
+Remember: **When in doubt, be conservative**. It's better to prune less frequently or with smaller limits than to risk removing data that might still be needed. 

--- a/SPEC.md
+++ b/SPEC.md
@@ -709,33 +709,41 @@ contract implementation.
 ```rust
 PruneData {
     rollup_height: u64,
-    prune_finality_signatures: Option<bool>,
-    prune_public_randomness_values: Option<bool>,
     max_signatures_to_prune: Option<u32>,
-    max_values_to_prune: Option<u32>,
+    max_pub_rand_values_to_prune: Option<u32>,
 }
 ```
 
+**Parameter Semantics:**
+- `rollup_height`: Remove all data for rollup blocks with height ≤ this value.
+- `max_signatures_to_prune`: Maximum number of finality signatures to prune in a single operation.
+  - If `None`, the default value is 50.
+  - If `Some(0)`, disables pruning of finality signatures for this call.
+- `max_pub_rand_values_to_prune`: Maximum number of public randomness values to prune in a single operation.
+  - If `None`, the default value is 20.
+  - If `Some(0)`, disables pruning of public randomness values for this call.
+
 **Expected Behaviour:**
 - This message can be called by the admin only.
-- It removes old data for rollup blocks with height <= `rollup_height`.
-- The admin can choose to prune finality signatures, public randomness values, or both, in a single call.
+- It removes old data for rollup blocks with height ≤ `rollup_height`.
 - The operation is irreversible. The admin is responsible for ensuring that the pruning height is safe and that no data is still being used for the affected height range.
-- Per-type limits (`max_signatures_to_prune`, `max_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
-- The response includes attributes indicating how many items of each type were pruned.
+- Per-type limits (`max_signatures_to_prune`, `max_pub_rand_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
+- The response includes attributes indicating how many items of each type were pruned:
+  - `pruned_signatures`
+  - `pruned_pub_rand_values`
 
 **Example:**
 ```json
 {
   "prune_data": {
     "rollup_height": 1000,
-    "prune_finality_signatures": true,
-    "prune_public_randomness_values": true,
     "max_signatures_to_prune": 50,
-    "max_values_to_prune": 20
+    "max_pub_rand_values_to_prune": 20
   }
 }
 ```
+- To prune only finality signatures, set `"max_pub_rand_values_to_prune": 0`.
+- To prune only public randomness values, set `"max_signatures_to_prune": 0`.
 
 **Breaking Change Note:**
 - The key structure for `PUB_RAND_VALUES` is now `(u64, &[u8])` (was `(&[u8], u64)`), enabling efficient range queries and unified pruning. This is a breaking change for on-chain state, but improves performance and consistency.

--- a/SPEC.md
+++ b/SPEC.md
@@ -748,9 +748,6 @@ PruneData {
 **Breaking Change Note:**
 - The key structure for `PUB_RAND_VALUES` is now `(u64, &[u8])` (was `(&[u8], u64)`), enabling efficient range queries and unified pruning. This is a breaking change for on-chain state, but improves performance and consistency.
 
-**Deprecated:**
-- The separate `PruneFinalitySignatures` and `PrunePublicRandomnessValues` messages are replaced by `PruneData`.
-
 ### 4.8. Finality contract queries
 
 The finality contract query requirements are divided into core finality

--- a/SPEC.md
+++ b/SPEC.md
@@ -710,6 +710,7 @@ contract implementation.
 PruneData {
     rollup_height: u64,
     max_signatures_to_prune: Option<u32>,
+    max_signatories_to_prune: Option<u32>,
     max_pub_rand_values_to_prune: Option<u32>,
 }
 ```
@@ -719,17 +720,21 @@ PruneData {
 - `max_signatures_to_prune`: Maximum number of finality signatures to prune in a single operation.
   - If `None`, the default value is 50.
   - If `Some(0)`, disables pruning of finality signatures for this call.
+- `max_signatories_to_prune`: Maximum number of signatories by block hash entries to prune in a single operation.
+  - If `None`, the default value is 50.
+  - If `Some(0)`, disables pruning of signatories for this call.
 - `max_pub_rand_values_to_prune`: Maximum number of public randomness values to prune in a single operation.
-  - If `None`, the default value is 20.
+  - If `None`, the default value is 50.
   - If `Some(0)`, disables pruning of public randomness values for this call.
 
 **Expected Behaviour:**
 - This message can be called by the admin only.
 - It removes old data for rollup blocks with height ≤ `rollup_height`.
 - The operation is irreversible. The admin is responsible for ensuring that the pruning height is safe and that no data is still being used for the affected height range.
-- Per-type limits (`max_signatures_to_prune`, `max_pub_rand_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
+- Per-type limits (`max_signatures_to_prune`, `max_signatories_to_prune`, `max_pub_rand_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
 - The response includes attributes indicating how many items of each type were pruned:
   - `pruned_signatures`
+  - `pruned_signatories`
   - `pruned_pub_rand_values`
 
 **Example:**
@@ -738,12 +743,14 @@ PruneData {
   "prune_data": {
     "rollup_height": 1000,
     "max_signatures_to_prune": 50,
+    "max_signatories_to_prune": 50,
     "max_pub_rand_values_to_prune": 20
   }
 }
 ```
-- To prune only finality signatures, set `"max_pub_rand_values_to_prune": 0`.
-- To prune only public randomness values, set `"max_signatures_to_prune": 0`.
+- To prune only finality signatures, set `"max_signatories_to_prune": 0` and `"max_pub_rand_values_to_prune": 0`.
+- To prune only signatories, set `"max_signatures_to_prune": 0` and `"max_pub_rand_values_to_prune": 0`.
+- To prune only public randomness values, set `"max_signatures_to_prune": 0` and `"max_signatories_to_prune": 0`.
 
 **Breaking Change Note:**
 - The key structure for `PUB_RAND_VALUES` is now `(u64, &[u8])` (was `(&[u8], u64)`), enabling efficient range queries and unified pruning. This is a breaking change for on-chain state, but improves performance and consistency.

--- a/SPEC.md
+++ b/SPEC.md
@@ -710,19 +710,16 @@ contract implementation.
 PruneData {
     rollup_height: u64,
     max_signatures_to_prune: Option<u32>,
-    max_signatories_to_prune: Option<u32>,
     max_pub_rand_values_to_prune: Option<u32>,
 }
 ```
 
 **Parameter Semantics:**
 - `rollup_height`: Remove all data for rollup blocks with height ≤ this value.
-- `max_signatures_to_prune`: Maximum number of finality signatures to prune in a single operation.
+- `max_signatures_to_prune`: Maximum number of finality signatures and signatories to prune in a single operation.
+  - Since every signature has a corresponding signatory record, this limit applies to both.
   - If `None`, the default value is 50.
-  - If `Some(0)`, disables pruning of finality signatures for this call.
-- `max_signatories_to_prune`: Maximum number of signatories by block hash entries to prune in a single operation.
-  - If `None`, the default value is 50.
-  - If `Some(0)`, disables pruning of signatories for this call.
+  - If `Some(0)`, disables pruning of finality signatures and signatories for this call.
 - `max_pub_rand_values_to_prune`: Maximum number of public randomness values to prune in a single operation.
   - If `None`, the default value is 50.
   - If `Some(0)`, disables pruning of public randomness values for this call.
@@ -731,7 +728,7 @@ PruneData {
 - This message can be called by the admin only.
 - It removes old data for rollup blocks with height ≤ `rollup_height`.
 - The operation is irreversible. The admin is responsible for ensuring that the pruning height is safe and that no data is still being used for the affected height range.
-- Per-type limits (`max_signatures_to_prune`, `max_signatories_to_prune`, `max_pub_rand_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
+- Per-type limits (`max_signatures_to_prune`, `max_pub_rand_values_to_prune`) prevent gas exhaustion; multiple calls may be required for large amounts of data.
 - The response includes attributes indicating how many items of each type were pruned:
   - `pruned_signatures`
   - `pruned_signatories`
@@ -743,14 +740,12 @@ PruneData {
   "prune_data": {
     "rollup_height": 1000,
     "max_signatures_to_prune": 50,
-    "max_signatories_to_prune": 50,
     "max_pub_rand_values_to_prune": 20
   }
 }
 ```
-- To prune only finality signatures, set `"max_signatories_to_prune": 0` and `"max_pub_rand_values_to_prune": 0`.
-- To prune only signatories, set `"max_signatures_to_prune": 0` and `"max_pub_rand_values_to_prune": 0`.
-- To prune only public randomness values, set `"max_signatures_to_prune": 0` and `"max_signatories_to_prune": 0`.
+- To prune only finality signatures and signatories, set `"max_pub_rand_values_to_prune": 0`.
+- To prune only public randomness values, set `"max_signatures_to_prune": 0`.
 
 **Breaking Change Note:**
 - The key structure for `PUB_RAND_VALUES` is now `(u64, &[u8])` (was `(&[u8], u64)`), enabling efficient range queries and unified pruning. This is a breaking change for on-chain state, but improves performance and consistency.

--- a/contracts/finality/schema/finality.json
+++ b/contracts/finality/schema/finality.json
@@ -188,6 +188,49 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "description": "Prune old data (finality signatures, signatories by block hash, and public randomness values).\n\nThis message can be called by the admin only. It removes old data for rollup blocks with height <= rollup_height.\n\nWARNING: This operation is irreversible. The admin is responsible for ensuring that the pruning height is safe and that no data is still being used for the affected height range.",
+        "type": "object",
+        "required": [
+          "prune_data"
+        ],
+        "properties": {
+          "prune_data": {
+            "type": "object",
+            "required": [
+              "rollup_height"
+            ],
+            "properties": {
+              "max_pub_rand_values_to_prune": {
+                "description": "Maximum number of public randomness values to prune in a single operation. This prevents gas exhaustion when there are many old values. If not provided, the default value is 50.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "max_signatures_to_prune": {
+                "description": "Maximum number of finality signatures and signatories to prune in a single operation. Since every signature has a corresponding signatory record, this limit applies to both. This prevents gas exhaustion when there are many old entries. If not provided, the default value is 50.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "rollup_height": {
+                "description": "Remove all data for rollup blocks with height <= this value. The admin should ensure this height provides sufficient safety margin for chain reorganizations and data submission delays.",
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {

--- a/contracts/finality/schema/raw/execute.json
+++ b/contracts/finality/schema/raw/execute.json
@@ -160,6 +160,49 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Prune old data (finality signatures, signatories by block hash, and public randomness values).\n\nThis message can be called by the admin only. It removes old data for rollup blocks with height <= rollup_height.\n\nWARNING: This operation is irreversible. The admin is responsible for ensuring that the pruning height is safe and that no data is still being used for the affected height range.",
+      "type": "object",
+      "required": [
+        "prune_data"
+      ],
+      "properties": {
+        "prune_data": {
+          "type": "object",
+          "required": [
+            "rollup_height"
+          ],
+          "properties": {
+            "max_pub_rand_values_to_prune": {
+              "description": "Maximum number of public randomness values to prune in a single operation. This prevents gas exhaustion when there are many old values. If not provided, the default value is 50.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "max_signatures_to_prune": {
+              "description": "Maximum number of finality signatures and signatories to prune in a single operation. Since every signature has a corresponding signatory record, this limit applies to both. This prevents gas exhaustion when there are many old entries. If not provided, the default value is 50.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "rollup_height": {
+              "description": "Remove all data for rollup blocks with height <= this value. The admin should ensure this height provides sufficient safety margin for chain reorganizations and data submission delays.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -127,14 +127,12 @@ pub fn execute(
         ExecuteMsg::PruneData {
             rollup_height,
             max_signatures_to_prune,
-            max_signatories_to_prune,
             max_pub_rand_values_to_prune,
         } => handle_prune_data(
             deps,
             info,
             rollup_height,
             max_signatures_to_prune,
-            max_signatories_to_prune,
             max_pub_rand_values_to_prune,
         ),
     }
@@ -394,7 +392,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 105,
             max_signatures_to_prune: Some(10),
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: None,
         };
 
@@ -427,7 +424,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 200,
             max_signatures_to_prune: None,
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: None,
         };
 
@@ -475,8 +471,7 @@ pub(crate) mod tests {
         // Test successful pruning by admin
         let msg = ExecuteMsg::PruneData {
             rollup_height: 105,
-            max_signatures_to_prune: Some(0),
-            max_signatories_to_prune: Some(10),
+            max_signatures_to_prune: Some(10),
             max_pub_rand_values_to_prune: None,
         };
 
@@ -489,7 +484,7 @@ pub(crate) mod tests {
         assert_eq!(response.attributes[1].key, "rollup_height");
         assert_eq!(response.attributes[1].value, "105");
         assert_eq!(response.attributes[2].key, "pruned_signatures");
-        assert_eq!(response.attributes[2].value, "0");
+        assert_eq!(response.attributes[2].value, "6"); // Heights 100-105
         assert_eq!(response.attributes[3].key, "pruned_signatories");
         assert_eq!(response.attributes[3].value, "6"); // Heights 100-105
         assert_eq!(response.attributes[4].key, "pruned_pub_rand_values");
@@ -499,7 +494,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 200,
             max_signatures_to_prune: None,
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: None,
         };
 
@@ -534,7 +528,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 105,
             max_signatures_to_prune: None,
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: Some(10),
         };
 
@@ -569,7 +562,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 200,
             max_signatures_to_prune: None,
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: None,
         };
 
@@ -620,7 +612,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 105,
             max_signatures_to_prune: Some(10),
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: Some(10),
         };
 
@@ -659,7 +650,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 108,
             max_signatures_to_prune: Some(5),
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: Some(0),
         };
 
@@ -678,7 +668,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 108,
             max_signatures_to_prune: Some(0),
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: Some(5),
         };
 
@@ -698,7 +687,6 @@ pub(crate) mod tests {
         let msg = ExecuteMsg::PruneData {
             rollup_height: 200,
             max_signatures_to_prune: Some(0),
-            max_signatories_to_prune: None,
             max_pub_rand_values_to_prune: Some(0),
         };
 

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -121,6 +121,24 @@ pub fn execute(
             // Validate and set the new admin address
             Ok(ADMIN.execute_update_admin(deps, info, Some(api.addr_validate(&admin)?))?)
         }
+        ExecuteMsg::PruneFinalitySignatures {
+            rollup_height,
+            max_signatures_to_prune,
+        } => {
+            // Ensure only admin can call this
+            ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
+
+            let pruned_count = crate::state::finality::prune_finality_signatures(
+                deps.storage,
+                rollup_height,
+                max_signatures_to_prune,
+            )?;
+
+            Ok(Response::new()
+                .add_attribute("action", "prune_finality_signatures")
+                .add_attribute("rollup_height", rollup_height.to_string())
+                .add_attribute("pruned_count", pruned_count.to_string()))
+        }
     }
 }
 

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -115,6 +115,24 @@ pub enum ExecuteMsg {
     /// This message can be called by the admin only.
     /// The new admin address must be a valid Cosmos address.
     UpdateAdmin { admin: String },
+    /// Prune old finality signatures.
+    ///
+    /// This message can be called by the admin only.
+    /// It removes all finality signatures for rollup blocks with height <= rollup_height.
+    ///
+    /// WARNING: This operation is irreversible. The admin is responsible for ensuring
+    /// that the pruning height is safe and that no finality signatures are still
+    /// being submitted for the affected height range.
+    PruneFinalitySignatures {
+        /// Remove all signatures for rollup blocks with height <= this value.
+        /// The admin should ensure this height provides sufficient safety margin
+        /// for chain reorganizations and finality signature submission delays.
+        rollup_height: u64,
+        /// Maximum number of signatures to prune in a single operation.
+        /// This prevents gas exhaustion when there are many old signatures.
+        /// If more signatures need pruning, multiple calls may be required.
+        max_signatures_to_prune: Option<u32>,
+    },
 }
 
 #[cw_serde]

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -133,6 +133,24 @@ pub enum ExecuteMsg {
         /// If more signatures need pruning, multiple calls may be required.
         max_signatures_to_prune: Option<u32>,
     },
+    /// Prune old public randomness values.
+    ///
+    /// This message can be called by the admin only.
+    /// It removes all public randomness values for rollup blocks with height <= rollup_height.
+    ///
+    /// WARNING: This operation is irreversible. The admin is responsible for ensuring
+    /// that the pruning height is safe and that no public randomness values are still
+    /// being used for the affected height range.
+    PrunePublicRandomnessValues {
+        /// Remove all values for rollup blocks with height <= this value.
+        /// The admin should ensure this height provides sufficient safety margin
+        /// for chain reorganizations and finality signature submission delays.
+        rollup_height: u64,
+        /// Maximum number of values to prune in a single operation.
+        /// This prevents gas exhaustion when there are many old values.
+        /// If more values need pruning, multiple calls may be required.
+        max_values_to_prune: Option<u32>,
+    },
 }
 
 #[cw_serde]

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -115,40 +115,30 @@ pub enum ExecuteMsg {
     /// This message can be called by the admin only.
     /// The new admin address must be a valid Cosmos address.
     UpdateAdmin { admin: String },
-    /// Prune old finality signatures.
+    /// Prune old data (finality signatures and/or public randomness values).
     ///
     /// This message can be called by the admin only.
-    /// It removes all finality signatures for rollup blocks with height <= rollup_height.
+    /// It removes old data for rollup blocks with height <= rollup_height.
     ///
     /// WARNING: This operation is irreversible. The admin is responsible for ensuring
-    /// that the pruning height is safe and that no finality signatures are still
-    /// being submitted for the affected height range.
-    PruneFinalitySignatures {
-        /// Remove all signatures for rollup blocks with height <= this value.
+    /// that the pruning height is safe and that no data is still being used
+    /// for the affected height range.
+    PruneData {
+        /// Remove all data for rollup blocks with height <= this value.
         /// The admin should ensure this height provides sufficient safety margin
-        /// for chain reorganizations and finality signature submission delays.
+        /// for chain reorganizations and data submission delays.
         rollup_height: u64,
-        /// Maximum number of signatures to prune in a single operation.
+        /// Whether to prune finality signatures.
+        prune_finality_signatures: Option<bool>,
+        /// Whether to prune public randomness values.
+        prune_public_randomness_values: Option<bool>,
+        /// Maximum number of finality signatures to prune in a single operation.
         /// This prevents gas exhaustion when there are many old signatures.
-        /// If more signatures need pruning, multiple calls may be required.
+        /// If not provided, the default value is 50.
         max_signatures_to_prune: Option<u32>,
-    },
-    /// Prune old public randomness values.
-    ///
-    /// This message can be called by the admin only.
-    /// It removes all public randomness values for rollup blocks with height <= rollup_height.
-    ///
-    /// WARNING: This operation is irreversible. The admin is responsible for ensuring
-    /// that the pruning height is safe and that no public randomness values are still
-    /// being used for the affected height range.
-    PrunePublicRandomnessValues {
-        /// Remove all values for rollup blocks with height <= this value.
-        /// The admin should ensure this height provides sufficient safety margin
-        /// for chain reorganizations and finality signature submission delays.
-        rollup_height: u64,
-        /// Maximum number of values to prune in a single operation.
+        /// Maximum number of public randomness values to prune in a single operation.
         /// This prevents gas exhaustion when there are many old values.
-        /// If more values need pruning, multiple calls may be required.
+        /// If not provided, the default value is 20.
         max_values_to_prune: Option<u32>,
     },
 }

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -115,7 +115,7 @@ pub enum ExecuteMsg {
     /// This message can be called by the admin only.
     /// The new admin address must be a valid Cosmos address.
     UpdateAdmin { admin: String },
-    /// Prune old data (finality signatures and/or public randomness values).
+    /// Prune old data (finality signatures and public randomness values).
     ///
     /// This message can be called by the admin only.
     /// It removes old data for rollup blocks with height <= rollup_height.
@@ -128,10 +128,6 @@ pub enum ExecuteMsg {
         /// The admin should ensure this height provides sufficient safety margin
         /// for chain reorganizations and data submission delays.
         rollup_height: u64,
-        /// Whether to prune finality signatures.
-        prune_finality_signatures: Option<bool>,
-        /// Whether to prune public randomness values.
-        prune_public_randomness_values: Option<bool>,
         /// Maximum number of finality signatures to prune in a single operation.
         /// This prevents gas exhaustion when there are many old signatures.
         /// If not provided, the default value is 50.
@@ -139,7 +135,7 @@ pub enum ExecuteMsg {
         /// Maximum number of public randomness values to prune in a single operation.
         /// This prevents gas exhaustion when there are many old values.
         /// If not provided, the default value is 20.
-        max_values_to_prune: Option<u32>,
+        max_pub_rand_values_to_prune: Option<u32>,
     },
 }
 

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -115,7 +115,7 @@ pub enum ExecuteMsg {
     /// This message can be called by the admin only.
     /// The new admin address must be a valid Cosmos address.
     UpdateAdmin { admin: String },
-    /// Prune old data (finality signatures and public randomness values).
+    /// Prune old data (finality signatures, signatories by block hash, and public randomness values).
     ///
     /// This message can be called by the admin only.
     /// It removes old data for rollup blocks with height <= rollup_height.
@@ -132,9 +132,13 @@ pub enum ExecuteMsg {
         /// This prevents gas exhaustion when there are many old signatures.
         /// If not provided, the default value is 50.
         max_signatures_to_prune: Option<u32>,
+        /// Maximum number of signatories by block hash entries to prune in a single operation.
+        /// This prevents gas exhaustion when there are many old entries.
+        /// If not provided, the default value is 50.
+        max_signatories_to_prune: Option<u32>,
         /// Maximum number of public randomness values to prune in a single operation.
         /// This prevents gas exhaustion when there are many old values.
-        /// If not provided, the default value is 20.
+        /// If not provided, the default value is 50.
         max_pub_rand_values_to_prune: Option<u32>,
     },
 }

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -128,14 +128,11 @@ pub enum ExecuteMsg {
         /// The admin should ensure this height provides sufficient safety margin
         /// for chain reorganizations and data submission delays.
         rollup_height: u64,
-        /// Maximum number of finality signatures to prune in a single operation.
-        /// This prevents gas exhaustion when there are many old signatures.
-        /// If not provided, the default value is 50.
-        max_signatures_to_prune: Option<u32>,
-        /// Maximum number of signatories by block hash entries to prune in a single operation.
+        /// Maximum number of finality signatures and signatories to prune in a single operation.
+        /// Since every signature has a corresponding signatory record, this limit applies to both.
         /// This prevents gas exhaustion when there are many old entries.
         /// If not provided, the default value is 50.
-        max_signatories_to_prune: Option<u32>,
+        max_signatures_to_prune: Option<u32>,
         /// Maximum number of public randomness values to prune in a single operation.
         /// This prevents gas exhaustion when there are many old values.
         /// If not provided, the default value is 50.

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -146,7 +146,7 @@ pub(crate) fn prune_finality_signatures(
         .range(
             storage,
             None,
-            Some(Bound::exclusive((rollup_height + 1, vec![].as_slice()))),
+            Some(Bound::exclusive((rollup_height + 1, &[] as &[u8]))),
             cosmwasm_std::Order::Ascending,
         )
         .take(max_to_prune)

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -1,4 +1,4 @@
-use crate::error::ContractError;
+use crate::{error::ContractError, state::pruning::{DEFAULT_PRUNING, MAX_PRUNING}};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{StdResult, Storage};
 use cw_storage_plus::{Bound, Map};
@@ -109,9 +109,6 @@ pub fn insert_finality_sig_and_signatory(
 
     Ok(())
 }
-
-const MAX_PRUNING: u32 = 30;
-const DEFAULT_PRUNING: u32 = 10;
 
 /// Prunes old finality signatures for all finality providers.
 ///

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -146,7 +146,7 @@ pub(crate) fn prune_finality_signatures(
         .range(
             storage,
             None,
-            Some(Bound::inclusive((rollup_height + 1, vec![].as_slice()))),
+            Some(Bound::exclusive((rollup_height + 1, vec![].as_slice()))),
             cosmwasm_std::Order::Ascending,
         )
         .take(max_to_prune)

--- a/contracts/finality/src/state/mod.rs
+++ b/contracts/finality/src/state/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod finality;
+pub mod pruning;
 pub mod public_randomness;
 
 /// `Bytes` is a vector of bytes

--- a/contracts/finality/src/state/pruning.rs
+++ b/contracts/finality/src/state/pruning.rs
@@ -6,6 +6,16 @@ use crate::state::config::ADMIN;
 use crate::BabylonMsg;
 use crate::ContractError;
 
+/// The maximum number of items to prune in a single operation.
+pub(crate) const MAX_PRUNING: u32 = 100;
+
+/// The default number of items to prune in a single operation.
+pub(crate) const DEFAULT_PRUNING: u32 = 50;
+
+/// Handles the pruning of data from the contract.
+///
+/// This function prunes finality signatures and public randomness values for rollup blocks with height <= rollup_height.
+/// It's designed to be called manually by the admin to prevent indefinite storage growth.
 pub(crate) fn handle_prune_data(
     deps: DepsMut<BabylonQuery>,
     info: MessageInfo,

--- a/contracts/finality/src/state/pruning.rs
+++ b/contracts/finality/src/state/pruning.rs
@@ -14,13 +14,14 @@ pub(crate) const DEFAULT_PRUNING: u32 = 50;
 
 /// Handles the pruning of data from the contract.
 ///
-/// This function prunes finality signatures and public randomness values for rollup blocks with height <= rollup_height.
+/// This function prunes finality signatures, signatories by block hash, and public randomness values for rollup blocks with height <= rollup_height.
 /// It's designed to be called manually by the admin to prevent indefinite storage growth.
 pub(crate) fn handle_prune_data(
     deps: DepsMut<BabylonQuery>,
     info: MessageInfo,
     rollup_height: u64,
     max_signatures_to_prune: Option<u32>,
+    max_signatories_to_prune: Option<u32>,
     max_pub_rand_values_to_prune: Option<u32>,
 ) -> Result<Response<BabylonMsg>, ContractError> {
     // Ensure only admin can call this
@@ -37,6 +38,14 @@ pub(crate) fn handle_prune_data(
         max_signatures_to_prune,
     )?;
     response = response.add_attribute("pruned_signatures", pruned_signatures.to_string());
+
+    // Prune signatories by block hash
+    let pruned_signatories = crate::state::finality::prune_signatories_by_block_hash(
+        deps.storage,
+        rollup_height,
+        max_signatories_to_prune,
+    )?;
+    response = response.add_attribute("pruned_signatories", pruned_signatories.to_string());
 
     // Prune public randomness values
     let pruned_values = crate::state::public_randomness::prune_public_randomness_values(

--- a/contracts/finality/src/state/pruning.rs
+++ b/contracts/finality/src/state/pruning.rs
@@ -21,7 +21,6 @@ pub(crate) fn handle_prune_data(
     info: MessageInfo,
     rollup_height: u64,
     max_signatures_to_prune: Option<u32>,
-    max_signatories_to_prune: Option<u32>,
     max_pub_rand_values_to_prune: Option<u32>,
 ) -> Result<Response<BabylonMsg>, ContractError> {
     // Ensure only admin can call this
@@ -39,11 +38,11 @@ pub(crate) fn handle_prune_data(
     )?;
     response = response.add_attribute("pruned_signatures", pruned_signatures.to_string());
 
-    // Prune signatories by block hash
+    // Prune signatories by block hash (using the same limit as signatures)
     let pruned_signatories = crate::state::finality::prune_signatories_by_block_hash(
         deps.storage,
         rollup_height,
-        max_signatories_to_prune,
+        max_signatures_to_prune,
     )?;
     response = response.add_attribute("pruned_signatories", pruned_signatories.to_string());
 

--- a/contracts/finality/src/state/pruning.rs
+++ b/contracts/finality/src/state/pruning.rs
@@ -1,0 +1,40 @@
+use cosmwasm_std::{DepsMut, MessageInfo, Response};
+
+use babylon_bindings::BabylonQuery;
+
+use crate::state::config::ADMIN;
+use crate::BabylonMsg;
+use crate::ContractError;
+
+pub(crate) fn handle_prune_data(
+    deps: DepsMut<BabylonQuery>,
+    info: MessageInfo,
+    rollup_height: u64,
+    max_signatures_to_prune: Option<u32>,
+    max_pub_rand_values_to_prune: Option<u32>,
+) -> Result<Response<BabylonMsg>, ContractError> {
+    // Ensure only admin can call this
+    ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
+
+    let mut response = Response::new()
+        .add_attribute("action", "prune_data")
+        .add_attribute("rollup_height", rollup_height.to_string());
+
+    // Prune finality signatures
+    let pruned_signatures = crate::state::finality::prune_finality_signatures(
+        deps.storage,
+        rollup_height,
+        max_signatures_to_prune,
+    )?;
+    response = response.add_attribute("pruned_signatures", pruned_signatures.to_string());
+
+    // Prune public randomness values
+    let pruned_values = crate::state::public_randomness::prune_public_randomness_values(
+        deps.storage,
+        rollup_height,
+        max_pub_rand_values_to_prune,
+    )?;
+    response = response.add_attribute("pruned_pub_rand_values", pruned_values.to_string());
+
+    Ok(response)
+}

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -234,6 +234,60 @@ pub(crate) fn insert_pub_rand_value(
     Ok(())
 }
 
+const MAX_PUB_RAND_PRUNING: u32 = 50;
+const DEFAULT_PUB_RAND_PRUNING: u32 = 20;
+
+/// Prunes old public randomness values for all finality providers.
+///
+/// This function removes all public randomness values for rollup blocks with height <= rollup_height.
+/// It's designed to be called manually by the admin to prevent indefinite storage growth.
+///
+/// The function prunes up to `max_values_to_prune` old values per call
+/// to prevent gas exhaustion when there are many old values to clean up.
+///
+/// # Arguments
+///
+/// * `storage` - The storage instance to operate on
+/// * `rollup_height` - Remove all values for rollup blocks with height <= this value
+/// * `max_values_to_prune` - Maximum number of values to prune in this operation
+///     - If not provided, the default value is 20.
+///     - If provided, the value must be between 1 and 50.
+///
+/// # Returns
+///
+/// Returns the number of values that were pruned, or an error if the operation failed.
+pub(crate) fn prune_public_randomness_values(
+    storage: &mut dyn Storage,
+    rollup_height: u64,
+    max_values_to_prune: Option<u32>,
+) -> Result<usize, ContractError> {
+    let max_to_prune = max_values_to_prune
+        .unwrap_or(DEFAULT_PUB_RAND_PRUNING)
+        .min(MAX_PUB_RAND_PRUNING) as usize;
+
+    // Get max public randomness values to prune in range from storage, ordered by height (ascending)
+    let all_values = PUB_RAND_VALUES
+        .range(storage, None, None, cosmwasm_std::Order::Ascending)
+        .filter(|item| {
+            if let Ok((key, _)) = item {
+                let (_, height) = key;
+                *height <= rollup_height
+            } else {
+                false
+            }
+        })
+        .take(max_to_prune)
+        .collect::<cosmwasm_std::StdResult<Vec<_>>>()?;
+
+    for (key, _pub_rand_value) in &all_values {
+        let (fp_btc_pk, height) = key;
+        // Remove the value from storage
+        PUB_RAND_VALUES.remove(storage, (fp_btc_pk.as_slice(), *height));
+    }
+
+    Ok(all_values.len())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,5 +506,164 @@ mod tests {
                 _ => panic!("Expected PubRandAlreadyExists error, got {err:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_prune_public_randomness_values() {
+        let mut deps = mock_dependencies();
+        let fp_btc_pk1 = get_random_fp_pk();
+        let fp_btc_pk2 = get_random_fp_pk();
+
+        // Insert several public randomness values at different heights
+        let heights = vec![100, 200, 300, 400, 500];
+        let pub_rands: Vec<Vec<u8>> = heights.iter().map(|_| get_random_pub_rand()).collect();
+
+        // Insert values for first finality provider
+        for (i, &height) in heights.iter().enumerate() {
+            insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk1, height, &pub_rands[i])
+                .unwrap();
+        }
+
+        // Insert values for second finality provider
+        for (i, &height) in heights.iter().enumerate() {
+            insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk2, height, &pub_rands[i])
+                .unwrap();
+        }
+
+        // Verify values exist before pruning
+        for &height in &heights {
+            let val1 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk1, height).unwrap();
+            assert!(val1.is_some());
+            let val2 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk2, height).unwrap();
+            assert!(val2.is_some());
+        }
+
+        // Test pruning with rollup_height = 250
+        // This should prune values at heights 100, 200 for both finality providers
+        let pruned_count =
+            prune_public_randomness_values(deps.as_mut().storage, 250, None).unwrap();
+        assert_eq!(pruned_count, 4); // 2 values per FP = 4 total
+
+        // Verify old values are gone
+        for &height in &[100, 200] {
+            let val1 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk1, height).unwrap();
+            assert!(val1.is_none());
+            let val2 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk2, height).unwrap();
+            assert!(val2.is_none());
+        }
+
+        // Verify recent values are still there
+        for &height in &[300, 400, 500] {
+            let val1 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk1, height).unwrap();
+            assert!(val1.is_some());
+            let val2 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk2, height).unwrap();
+            assert!(val2.is_some());
+        }
+
+        // Test pruning with a very low height (should prune nothing)
+        let pruned_count2 =
+            prune_public_randomness_values(deps.as_mut().storage, 50, None).unwrap();
+        assert_eq!(pruned_count2, 0);
+
+        // Verify values are still there
+        for &height in &[300, 400, 500] {
+            let val1 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk1, height).unwrap();
+            assert!(val1.is_some());
+            let val2 = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk2, height).unwrap();
+            assert!(val2.is_some());
+        }
+    }
+
+    #[test]
+    fn test_prune_public_randomness_values_with_limit() {
+        let mut deps = mock_dependencies();
+        let fp_btc_pk = get_random_fp_pk();
+
+        // Insert many values
+        let heights: Vec<u64> = (100..150).collect(); // 50 values
+        let pub_rands: Vec<Vec<u8>> = heights.iter().map(|_| get_random_pub_rand()).collect();
+
+        for (i, &height) in heights.iter().enumerate() {
+            insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk, height, &pub_rands[i])
+                .unwrap();
+        }
+
+        // Test pruning with a limit of 10 (should only prune 10 values)
+        let pruned_count =
+            prune_public_randomness_values(deps.as_mut().storage, 200, Some(10)).unwrap();
+        assert_eq!(pruned_count, 10);
+
+        // Verify only first 10 values are gone
+        for &height in &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109] {
+            let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
+            assert!(val.is_none());
+        }
+
+        // Verify remaining values are still there
+        for &height in &[110, 111, 112, 113, 114, 115, 116, 117, 118, 119] {
+            let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
+            assert!(val.is_some());
+        }
+    }
+
+    #[test]
+    fn test_prune_public_randomness_values_empty_storage() {
+        let mut deps = mock_dependencies();
+
+        // Test pruning on empty storage
+        let pruned_count =
+            prune_public_randomness_values(deps.as_mut().storage, 1000, None).unwrap();
+        assert_eq!(pruned_count, 0);
+    }
+
+    #[test]
+    fn test_prune_public_randomness_values_max_limit() {
+        let mut deps = mock_dependencies();
+        let fp_btc_pk = get_random_fp_pk();
+
+        // Insert some values
+        for height in 100..110 {
+            let pub_rand = get_random_pub_rand();
+            insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk, height, &pub_rand).unwrap();
+        }
+
+        // Test with max limit (50) - should respect the limit
+        let pruned_count =
+            prune_public_randomness_values(deps.as_mut().storage, 200, Some(100)).unwrap();
+        assert_eq!(pruned_count, 10); // Only 10 values exist, all should be pruned
+
+        // Verify all values are gone
+        for height in 100..110 {
+            let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
+            assert!(val.is_none());
+        }
+    }
+
+    #[test]
+    fn test_prune_public_randomness_values_exact_height() {
+        let mut deps = mock_dependencies();
+        let fp_btc_pk = get_random_fp_pk();
+
+        // Insert values at specific heights
+        let heights = vec![100, 200, 300];
+        for &height in &heights {
+            let pub_rand = get_random_pub_rand();
+            insert_pub_rand_value(deps.as_mut().storage, &fp_btc_pk, height, &pub_rand).unwrap();
+        }
+
+        // Test pruning at exact height 200 (should include height 200)
+        let pruned_count =
+            prune_public_randomness_values(deps.as_mut().storage, 200, None).unwrap();
+        assert_eq!(pruned_count, 2); // Heights 100 and 200
+
+        // Verify heights 100 and 200 are gone
+        for &height in &[100, 200] {
+            let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
+            assert!(val.is_none());
+        }
+
+        // Verify height 300 is still there
+        let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, 300).unwrap();
+        assert!(val.is_some());
     }
 }

--- a/contracts/finality/src/state/public_randomness.rs
+++ b/contracts/finality/src/state/public_randomness.rs
@@ -1,5 +1,6 @@
 use crate::custom_queries::get_last_finalized_epoch;
 use crate::error::ContractError;
+use crate::state::pruning::{DEFAULT_PRUNING, MAX_PRUNING};
 use crate::state::Bytes;
 use babylon_bindings::BabylonQuery;
 use cosmwasm_schema::cw_serde;
@@ -234,9 +235,6 @@ pub(crate) fn insert_pub_rand_value(
     Ok(())
 }
 
-const MAX_PUB_RAND_PRUNING: u32 = 50;
-const DEFAULT_PUB_RAND_PRUNING: u32 = 20;
-
 /// Prunes old public randomness values for all finality providers.
 ///
 /// This function removes all public randomness values for rollup blocks with height <= rollup_height.
@@ -262,8 +260,8 @@ pub(crate) fn prune_public_randomness_values(
     max_values_to_prune: Option<u32>,
 ) -> Result<usize, ContractError> {
     let max_to_prune = max_values_to_prune
-        .unwrap_or(DEFAULT_PUB_RAND_PRUNING)
-        .min(MAX_PUB_RAND_PRUNING) as usize;
+        .unwrap_or(DEFAULT_PRUNING)
+        .min(MAX_PRUNING) as usize;
 
     // Get max public randomness values to prune in range from storage, ordered by height (ascending)
     let all_values = PUB_RAND_VALUES


### PR DESCRIPTION
## Description

Adds a manual execution handler for pruning data (finality signatures, signatories, and pub rand values). The data to be pruned is the one that is older than the provided `rollup_height` parameter.

Admin should exercise caution when pruning data, making sure that the provided `rollup_height` is old enough not to affect current block signing or pub rand values checking.

Automatic "in passing" pruning of data could be done, and be more convenient, but to be safe, it would require storing the associated babylon height of the data to be pruned during data insertion.
The rollup height passed as parameter to the signature and pub rand commitment calls is user provided, and therefore arbitrary, and cannot be trusted as a sentinel for data pruning.

Doing this automatic pruning is left as a future improvement, as it'll require changing the underlying storage, and adding indexes by babylon height to the data.

## Checklist

- [x] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification
- [x] I have updated the schema by running `cargo gen-schema`
