### PR TITLE
chore: store conflictings finality sigs in storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,36 +39,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### State and API breaking
 
-* [#65](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/65) Remove `is_enabled` flag and associated functionality from finality contract
-* [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Timestamped public randomness commitments.
-  Breaks `PubRandCommit` struct that is being used for both storage and queries.
+* [#65](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/65) Remove
+  `is_enabled` flag and associated functionality from finality contract
+* [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40)
+  Timestamped public randomness commitments. Breaks `PubRandCommit` struct that
+  is being used for both storage and queries.
+* [#75](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/75) chore:
+  store conflictings finality sigs in storage
 
 ### API breaking
 
-* [#60](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/60) feat: add signing context
+* [#60](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/60) feat:
+  add signing context
 
 ### State breaking
 
-* [#55](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/55) evidence: remove evidence DB
-* [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore: use consistent naming for state maps
-* [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Refactor votes storage.
+* [#55](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/55)
+  evidence: remove evidence DB
+* [#35](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/35) chore:
+  use consistent naming for state maps
+* [#40](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/40) Refactor
+  votes storage.
 
 ### Improvements
 
-* [#71](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/71) chore: fix signing context
-* [#69](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/69) Define state setter functions
-* [#64](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/64) chore: clean up metadata
-* [#62](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/62) Add consumer ID format validation and admin address validation during contract instantiation and admin updates
-* [#56](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/56) e2e: migrate e2e from babylon to contract repo
-* [#57](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/57) Fix block voters response type annotation
-* [#51](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/51) finality: refactor handle_finality_signature and revise unit tests
-* [#52](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/52) chore: remove unused fields in FP struct.
-* [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename `hash` to `hash_hex`.
-* [#42](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/42) test: Add unit tests for public randomness commitment validation.
-* [#47](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/47) Create state/evidence.rs file and define setters/getters.
-* [#23](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/23) Clean up dependencies to cosmos-bsn-contracts.
-* [#24](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/24) Validate public randomness commitment.
-* [#25](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/25) Improve `check_fp_exist` to ensure FP is not slashed.
-* [#29](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/29) feat: Remove slashing evidence message
-* [59](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/59) chore: add missing validations in handle_public_randomness_commit
-* [70](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/70) chore: new query for fetch all pub rand commit
+* [#71](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/71) chore:
+  fix signing context
+* [#69](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/69) Define
+  state setter functions
+* [#64](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/64) chore:
+  clean up metadata
+* [#62](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/62) Add
+  consumer ID format validation and admin address validation during contract
+  instantiation and admin updates
+* [#56](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/56) e2e:
+  migrate e2e from babylon to contract repo
+* [#57](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/57) Fix
+  block voters response type annotation
+* [#51](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/51)
+  finality: refactor handle_finality_signature and revise unit tests
+* [#52](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/52) chore:
+  remove unused fields in FP struct.
+* [#31](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/31) Rename
+  `hash` to `hash_hex`.
+* [#42](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/42) test:
+  Add unit tests for public randomness commitment validation.
+* [#47](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/47) Create
+  state/evidence.rs file and define setters/getters.
+* [#23](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/23) Clean up
+  dependencies to cosmos-bsn-contracts.
+* [#24](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/24) Validate
+  public randomness commitment.
+* [#25](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/25) Improve
+  `check_fp_exist` to ensure FP is not slashed.
+* [#29](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/29) feat:
+  Remove slashing evidence message
+* [59](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/59) chore:
+  add missing validations in handle_public_randomness_commit
+* [70](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/70) chore:
+  new query for fetch all pub rand commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   Timestamped public randomness commitments. Breaks `PubRandCommit` struct that
   is being used for both storage and queries.
 * [#75](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/75) chore:
-  store conflictings finality sigs in storage
+  store conflicting finality sigs in storage
 
 ### API breaking
 

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -143,7 +143,7 @@ pub(crate) mod tests {
     use super::*;
     use std::marker::PhantomData;
 
-    use crate::state::finality::{list_finality_signatures, insert_finality_sig_and_signatory};
+    use crate::state::finality::{insert_finality_sig_and_signatory, list_finality_signatures};
     use crate::state::public_randomness::{get_pub_rand_value, insert_pub_rand_value};
     use crate::testutil::datagen::*;
     use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -143,7 +143,7 @@ pub(crate) mod tests {
     use super::*;
     use std::marker::PhantomData;
 
-    use crate::state::finality::{get_finality_signature, insert_finality_sig_and_signatory};
+    use crate::state::finality::{list_finality_signatures, insert_finality_sig_and_signatory};
     use crate::state::public_randomness::{get_pub_rand_value, insert_pub_rand_value};
     use crate::testutil::datagen::*;
     use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
@@ -384,7 +384,7 @@ pub(crate) mod tests {
 
         // Verify signatures exist before pruning
         for height in 100..110 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_some());
         }
 
@@ -410,13 +410,13 @@ pub(crate) mod tests {
 
         // Verify signatures are pruned
         for height in 100..106 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_none());
         }
 
         // Verify remaining signatures are still there
         for height in 106..110 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_some());
         }
 
@@ -602,7 +602,7 @@ pub(crate) mod tests {
 
         // Verify data exists before pruning
         for height in 100..110 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_some());
             let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
             assert!(val.is_some());
@@ -632,7 +632,7 @@ pub(crate) mod tests {
 
         // Verify data is pruned
         for height in 100..106 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_none());
             let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
             assert!(val.is_none());
@@ -640,7 +640,7 @@ pub(crate) mod tests {
 
         // Verify remaining data is still there
         for height in 106..110 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_some());
             let val = get_pub_rand_value(deps.as_ref().storage, &fp_btc_pk, height).unwrap();
             assert!(val.is_some());

--- a/contracts/finality/src/error.rs
+++ b/contracts/finality/src/error.rs
@@ -75,6 +75,8 @@ pub enum ContractError {
     PubRandAlreadyExists(String, u64),
     #[error("Duplicate signatory {0}")]
     DuplicateSignatory(String),
+    #[error("Duplicated finality signature for finality provider {0} at height {1}")]
+    DuplicatedFinalitySig(String, u64),
     #[error("Too few public randomness values: given {given}, required minimum {required}")]
     TooFewPubRand { given: u64, required: u64 },
     #[error("Block height overflow: start height {start_height} is equal or higher than (start height + num pub rand) {end_height}")]

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -1,7 +1,7 @@
 use crate::error::ContractError;
 use crate::msg::BabylonMsg;
 use crate::state::config::get_config;
-use crate::state::finality::{list_finality_signatures, insert_finality_sig_and_signatory};
+use crate::state::finality::{insert_finality_sig_and_signatory, list_finality_signatures};
 use crate::state::public_randomness::{
     get_timestamped_pub_rand_commit_for_height, insert_pub_rand_value, PubRandCommit,
 };
@@ -78,7 +78,7 @@ pub fn handle_finality_signature(
     if let Some(existing_sigs) = existing_finality_sigs {
         // Take the first existing signature for equivocation evidence
         let existing_sig = &existing_sigs[0];
-        
+
         // The finality provider has voted for a different signature at the same height!
         // send equivocation evidence to Babylon Genesis for slashing
         let msg = get_msg_equivocation_evidence(

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -37,8 +37,11 @@ pub fn handle_finality_signature(
         for existing_sig in existing_sigs {
             if existing_sig.finality_sig == signature {
                 deps.api.debug(&format!("Received duplicated finality vote. Height: {height}, Finality Provider: {fp_btc_pk_hex}"));
-                // Exactly the same vote already exists, return success to the provider
-                return Ok(Response::new());
+                // Exactly the same vote already exists, return error
+                return Err(ContractError::DuplicatedFinalitySig(
+                    fp_btc_pk_hex.to_string(),
+                    height,
+                ));
             }
         }
     }

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -80,7 +80,7 @@ pub fn handle_finality_signature(
     // Check for equivocation - if there are existing signatures, this is equivocation
     if let Some(existing_sigs) = existing_finality_sigs {
         // Take the first existing signature for equivocation evidence
-        let existing_sig = &existing_sigs[0];
+        let existing_sig = existing_sigs.iter().next().unwrap();
 
         // The finality provider has voted for a different signature at the same height!
         // send equivocation evidence to Babylon Genesis for slashing

--- a/contracts/finality/src/queries.rs
+++ b/contracts/finality/src/queries.rs
@@ -2,8 +2,8 @@ use babylon_bindings::BabylonQuery;
 use cosmwasm_std::Deps;
 
 use crate::error::ContractError;
-use crate::state::finality::list_finality_signatures;
 use crate::state::finality::get_signatories_by_block_hash;
+use crate::state::finality::list_finality_signatures;
 use crate::state::finality::FinalitySigInfo;
 use crate::state::public_randomness::get_pub_rand_value;
 use cosmwasm_schema::cw_serde;
@@ -42,13 +42,14 @@ pub fn query_block_voters(
             )?;
 
             // Find the signature for this specific block hash
-            let sig = sigs.iter().find(|s| s.block_hash == block_hash_bytes).ok_or(
-                ContractError::QueryBlockVoterError(
+            let sig = sigs
+                .iter()
+                .find(|s| s.block_hash == block_hash_bytes)
+                .ok_or(ContractError::QueryBlockVoterError(
                     height,
                     hash_hex.clone(),
                     format!("No signature found for block hash {hash_hex} by FP {fp_btc_pk_hex}"),
-                ),
-            )?;
+                ))?;
 
             let pub_rand =
                 get_pub_rand_value(deps.storage, &fp_btc_pk, height)?.ok_or_else(|| {

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -352,9 +352,9 @@ mod tests {
 
         // Verify signatures exist before pruning
         for &height in &heights {
-            let sig1 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
 
@@ -365,17 +365,17 @@ mod tests {
 
         // Verify old signatures are gone
         for &height in &[100, 200] {
-            let sig1 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_none());
-            let sig2 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_none());
         }
 
         // Verify recent signatures are still there
         for &height in &[300, 400, 500] {
-            let sig1 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
 
@@ -385,9 +385,9 @@ mod tests {
 
         // Verify signatures are still there
         for &height in &[300, 400, 500] {
-            let sig1 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
     }
@@ -419,13 +419,13 @@ mod tests {
 
         // Verify only first 10 signatures are gone
         for &height in &[100, 101, 102, 103, 104, 105, 106, 107, 108, 109] {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_none());
         }
 
         // Verify remaining signatures are still there
         for &height in &[110, 111, 112, 113, 114, 115, 116, 117, 118, 119] {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_some());
         }
     }
@@ -464,7 +464,7 @@ mod tests {
 
         // Verify all signatures are gone
         for height in 100..110 {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_none());
         }
     }
@@ -495,12 +495,12 @@ mod tests {
 
         // Verify heights 100 and 200 are gone
         for &height in &[100, 200] {
-            let sig = get_finality_signature(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
+            let sig = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk).unwrap();
             assert!(sig.is_none());
         }
 
         // Verify height 300 is still there
-        let sig = get_finality_signature(deps.as_ref().storage, 300, &fp_btc_pk).unwrap();
+        let sig = list_finality_signatures(deps.as_ref().storage, 300, &fp_btc_pk).unwrap();
         assert!(sig.is_some());
     }
 

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -5,7 +5,8 @@ use cw_storage_plus::Map;
 use std::collections::HashSet;
 
 /// Map of (block height, finality provider public key) tuples to the finality signatures for that height.
-const FINALITY_SIGNATURES: Map<(u64, &[u8]), Vec<FinalitySigInfo>> = Map::new("finality_signatures");
+const FINALITY_SIGNATURES: Map<(u64, &[u8]), Vec<FinalitySigInfo>> =
+    Map::new("finality_signatures");
 
 pub fn list_finality_signatures(
     storage: &dyn Storage,
@@ -28,9 +29,9 @@ pub fn insert_finality_signature(
     let mut signatures = FINALITY_SIGNATURES
         .may_load(storage, (height, fp_btc_pk))?
         .unwrap_or_default();
-    
+
     signatures.push(finality_sig_info);
-    
+
     FINALITY_SIGNATURES.save(storage, (height, fp_btc_pk), &signatures)
 }
 
@@ -187,8 +188,13 @@ mod tests {
             .unwrap();
         assert_eq!(finality_sig_info.len(), 2);
         // Should contain both signatures
-        assert!(finality_sig_info.iter().any(|sig| sig.finality_sig == signature && sig.block_hash == block_hash));
-        assert!(finality_sig_info.iter().any(|sig| sig.finality_sig == different_signature && sig.block_hash == different_block_hash));
+        assert!(finality_sig_info
+            .iter()
+            .any(|sig| sig.finality_sig == signature && sig.block_hash == block_hash));
+        assert!(finality_sig_info
+            .iter()
+            .any(|sig| sig.finality_sig == different_signature
+                && sig.block_hash == different_block_hash));
 
         // Verify signatory was added to the set for the new block hash
         let signatories =

--- a/contracts/finality/src/state/finality.rs
+++ b/contracts/finality/src/state/finality.rs
@@ -352,9 +352,11 @@ mod tests {
 
         // Verify signatures exist before pruning
         for &height in &heights {
-            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
 
@@ -365,17 +367,21 @@ mod tests {
 
         // Verify old signatures are gone
         for &height in &[100, 200] {
-            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_none());
-            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_none());
         }
 
         // Verify recent signatures are still there
         for &height in &[300, 400, 500] {
-            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
 
@@ -385,9 +391,11 @@ mod tests {
 
         // Verify signatures are still there
         for &height in &[300, 400, 500] {
-            let sig1 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
+            let sig1 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk1).unwrap();
             assert!(sig1.is_some());
-            let sig2 = list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
+            let sig2 =
+                list_finality_signatures(deps.as_ref().storage, height, &fp_btc_pk2).unwrap();
             assert!(sig2.is_some());
         }
     }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -179,7 +179,7 @@ func (s *FinalityContractTestSuite) Test3CommitAndTimestampPubRand() {
 	s.Equal(queryRes.BabylonEpoch, lastFinalizedEpoch)
 }
 
-func (s *FinalityContractTestSuite) Test4SubmitFinalitySignature() {
+func (s *FinalityContractTestSuite) Test4_SubmitFinalitySig() {
 	// get FP
 	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
 	fp, err := s.babylonApp.BTCStakingKeeper.GetFinalityProvider(s.ctx, fpBTCPK.MustMarshal())
@@ -191,7 +191,7 @@ func (s *FinalityContractTestSuite) Test4SubmitFinalitySignature() {
 	appHash := blockToVote.AppHash
 	idx := 0
 
-	// Store shared test data for duplicate test
+	// Store shared test data for Test4_SubmitFinalitySigDuplicate
 	sharedTestData = &TestSignatureData{
 		StartHeight: startHeight,
 		BlockToVote: blockToVote,
@@ -240,14 +240,14 @@ func (s *FinalityContractTestSuite) Test4SubmitFinalitySignature() {
 	s.Equal(fpBTCPK.MarshalHex(), votersRes[0].FpBtcPkHex)
 }
 
-func (s *FinalityContractTestSuite) Test4_5SubmitDuplicateFinalitySignature() {
+func (s *FinalityContractTestSuite) Test4_SubmitFinalitySigDuplicate() {
 	// get FP
 	fpBTCPK := bbn.NewBIP340PubKeyFromBTCPK(fpPK)
 	fp, err := s.babylonApp.BTCStakingKeeper.GetFinalityProvider(s.ctx, fpBTCPK.MustMarshal())
 	s.NoError(err)
 
-	// Use the same exact parameters as Test4
-	s.Require().NotNil(sharedTestData, "sharedTestData should be set by Test4")
+	// Use the same exact parameters as Test4_SubmitFinalitySig
+	s.Require().NotNil(sharedTestData, "sharedTestData should be set by Test4_SubmitFinalitySig")
 
 	startHeight := sharedTestData.StartHeight
 	blockToVote := sharedTestData.BlockToVote

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -129,8 +129,21 @@ type Proof struct {
 type BlockVoters struct {
 	Height uint64 `json:"height"`
 	// The block app hash is expected to be in hex format, without the 0x prefix
-	Hash string `json:"hash"`
+	HashHex string `json:"hash_hex"`
 }
 
-// List of finality provider public keys who voted for the block
-type BlockVotersResponse []string
+// List of finality provider information who voted for the block
+type BlockVotersResponse []BlockVoterInfo
+
+type BlockVoterInfo struct {
+	FpBtcPkHex        string          `json:"fp_btc_pk_hex"`
+	PubRand           []byte          `json:"pub_rand"`
+	FinalitySignature FinalitySigInfo `json:"finality_signature"`
+}
+
+type FinalitySigInfo struct {
+	// the finality signature
+	FinalitySig []byte `json:"finality_sig"`
+	// the block hash that the finality signature is for
+	BlockHash []byte `json:"block_hash"`
+}


### PR DESCRIPTION
## Description

Fixes - https://github.com/babylonlabs-io/rollup-bsn-contracts/issues/44 (store conflicting sigs)
Fixes - https://github.com/babylonlabs-io/rollup-bsn-contracts/issues/74 (contract should return err if duplicate sigs received)

<!-- Brief description of changes -->

## Checklist

- [x] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification
- [x] I have updated the schema by running `cargo gen-schema`
