### PR TITLE
feat: rate limiting for FP messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### API breaking
 
+* [#80](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/80) feat: rate limiting for FP messages
 * [#60](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/60) feat: add signing context
 
 ### State breaking

--- a/contracts/finality/schema/finality.json
+++ b/contracts/finality/schema/finality.json
@@ -9,7 +9,9 @@
     "required": [
       "admin",
       "bsn_id",
-      "min_pub_rand"
+      "max_msgs_per_interval",
+      "min_pub_rand",
+      "rate_limiting_interval"
     ],
     "properties": {
       "admin": {
@@ -18,7 +20,17 @@
       "bsn_id": {
         "type": "string"
       },
+      "max_msgs_per_interval": {
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0.0
+      },
       "min_pub_rand": {
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0.0
+      },
+      "rate_limiting_interval": {
         "type": "integer",
         "format": "uint64",
         "minimum": 0.0
@@ -510,11 +522,11 @@
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
-      "description": "Config are OP finality gadget's configuration",
       "type": "object",
       "required": [
         "bsn_id",
-        "min_pub_rand"
+        "min_pub_rand",
+        "rate_limiting"
       ],
       "properties": {
         "bsn_id": {
@@ -524,9 +536,37 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "rate_limiting": {
+          "$ref": "#/definitions/RateLimitingConfig"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "definitions": {
+        "RateLimitingConfig": {
+          "description": "RateLimitingConfig defines parameters for rate limiting message processing",
+          "type": "object",
+          "required": [
+            "block_interval",
+            "max_msgs_per_interval"
+          ],
+          "properties": {
+            "block_interval": {
+              "description": "Number of Babylon blocks in each interval",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "max_msgs_per_interval": {
+              "description": "Maximum number of messages allowed from each FP per interval",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      }
     },
     "first_pub_rand_commit": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/finality/schema/raw/instantiate.json
+++ b/contracts/finality/schema/raw/instantiate.json
@@ -5,7 +5,9 @@
   "required": [
     "admin",
     "bsn_id",
-    "min_pub_rand"
+    "max_msgs_per_interval",
+    "min_pub_rand",
+    "rate_limiting_interval"
   ],
   "properties": {
     "admin": {
@@ -14,7 +16,17 @@
     "bsn_id": {
       "type": "string"
     },
+    "max_msgs_per_interval": {
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
     "min_pub_rand": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "rate_limiting_interval": {
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0

--- a/contracts/finality/schema/raw/response_to_config.json
+++ b/contracts/finality/schema/raw/response_to_config.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Config",
-  "description": "Config are OP finality gadget's configuration",
   "type": "object",
   "required": [
     "bsn_id",
-    "min_pub_rand"
+    "min_pub_rand",
+    "rate_limiting"
   ],
   "properties": {
     "bsn_id": {
@@ -15,7 +15,35 @@
       "type": "integer",
       "format": "uint64",
       "minimum": 0.0
+    },
+    "rate_limiting": {
+      "$ref": "#/definitions/RateLimitingConfig"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "RateLimitingConfig": {
+      "description": "RateLimitingConfig defines parameters for rate limiting message processing",
+      "type": "object",
+      "required": [
+        "block_interval",
+        "max_msgs_per_interval"
+      ],
+      "properties": {
+        "block_interval": {
+          "description": "Number of Babylon blocks in each interval",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "max_msgs_per_interval": {
+          "description": "Maximum number of messages allowed from each FP per interval",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -47,7 +47,7 @@ pub fn query(
     msg: QueryMsg,
 ) -> Result<QueryResponse, ContractError> {
     match msg {
-        QueryMsg::Config {} => Ok(to_json_binary(&get_config(deps)?)?),
+        QueryMsg::Config {} => Ok(to_json_binary(&get_config(deps.storage)?)?),
         QueryMsg::Admin {} => Ok(to_json_binary(&ADMIN.query_admin(deps)?)?),
         QueryMsg::BlockVoters { height, hash_hex } => Ok(to_json_binary(&query_block_voters(
             deps, height, hash_hex,

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -34,7 +34,7 @@ pub fn instantiate(
     let config = Config {
         bsn_id: msg.bsn_id,
         min_pub_rand: msg.min_pub_rand,
-        max_msgs_per_hour: msg.max_msgs_per_hour,
+        max_msgs_per_interval: msg.max_msgs_per_interval,
     };
     set_config(deps.storage, &config)?;
 
@@ -143,7 +143,7 @@ pub(crate) mod tests {
     pub(crate) const INIT_ADMIN: &str = "initial_admin";
     const NEW_ADMIN: &str = "new_admin";
 
-    const MAX_MSGS_PER_HOUR: u32 = 100;
+    const MAX_MSGS_PER_INTERVAL: u32 = 100;
 
     // Define a type alias for OwnedDeps with BabylonQuery
     pub type BabylonDeps = OwnedDeps<MockStorage, MockApi, MockQuerier, BabylonQuery>;
@@ -167,7 +167,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(), // Admin provided
             bsn_id: "op-stack-l2-11155420".to_string(),
             min_pub_rand: 100,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -220,7 +220,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(),
             bsn_id: bsn_id.clone(),
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -268,7 +268,7 @@ pub(crate) mod tests {
             admin: invalid_admin.to_string(),
             bsn_id,
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -289,7 +289,7 @@ pub(crate) mod tests {
             admin: valid_admin.to_string(),
             bsn_id: invalid_bsn_id.to_string(),
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -310,7 +310,7 @@ pub(crate) mod tests {
             admin: valid_admin.to_string(),
             bsn_id: empty_bsn_id.to_string(),
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -332,7 +332,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(),
             bsn_id,
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -34,6 +34,7 @@ pub fn instantiate(
     let config = Config {
         bsn_id: msg.bsn_id,
         min_pub_rand: msg.min_pub_rand,
+        max_msgs_per_hour: msg.max_msgs_per_hour,
     };
     set_config(deps.storage, &config)?;
 
@@ -142,6 +143,8 @@ pub(crate) mod tests {
     pub(crate) const INIT_ADMIN: &str = "initial_admin";
     const NEW_ADMIN: &str = "new_admin";
 
+    const MAX_MSGS_PER_HOUR: u32 = 100;
+
     // Define a type alias for OwnedDeps with BabylonQuery
     pub type BabylonDeps = OwnedDeps<MockStorage, MockApi, MockQuerier, BabylonQuery>;
 
@@ -164,6 +167,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(), // Admin provided
             bsn_id: "op-stack-l2-11155420".to_string(),
             min_pub_rand: 100,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -216,6 +220,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(),
             bsn_id: bsn_id.clone(),
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -263,6 +268,7 @@ pub(crate) mod tests {
             admin: invalid_admin.to_string(),
             bsn_id,
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -283,6 +289,7 @@ pub(crate) mod tests {
             admin: valid_admin.to_string(),
             bsn_id: invalid_bsn_id.to_string(),
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -303,6 +310,7 @@ pub(crate) mod tests {
             admin: valid_admin.to_string(),
             bsn_id: empty_bsn_id.to_string(),
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);
@@ -324,6 +332,7 @@ pub(crate) mod tests {
             admin: init_admin.to_string(),
             bsn_id,
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
 
         let info = message_info(&deps.api.addr_make(CREATOR), &[]);

--- a/contracts/finality/src/error.rs
+++ b/contracts/finality/src/error.rs
@@ -89,6 +89,10 @@ pub enum ContractError {
     EmptyFpBtcPubKey,
     #[error("Invalid consumer ID: {0}")]
     InvalidBsnId(String),
+    #[error("Invalid rate limiting interval: {0}. Must be at least 1")]
+    InvalidRateLimitingInterval(u64),
+    #[error("Invalid max messages per interval: {0}. Must be at least 1")]
+    InvalidMaxMsgsPerInterval(u32),
     #[error("Rate limit exceeded for finality provider {fp_btc_pk} with limit {limit}")]
     RateLimitExceeded { fp_btc_pk: String, limit: u32 },
 }

--- a/contracts/finality/src/error.rs
+++ b/contracts/finality/src/error.rs
@@ -87,4 +87,6 @@ pub enum ContractError {
     EmptyFpBtcPubKey,
     #[error("Invalid consumer ID: {0}")]
     InvalidBsnId(String),
+    #[error("Rate limit exceeded for finality provider {fp_btc_pk} with limit {limit}")]
+    RateLimitExceeded { fp_btc_pk: String, limit: u32 },
 }

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -31,7 +31,7 @@ pub fn handle_finality_signature(
     let fp_btc_pk = hex::decode(fp_btc_pk_hex)?;
 
     // Ensure rate limiting; this step will fail if the rate limit is exceeded
-    accumulate_rate_limiter(deps.storage, &fp_btc_pk, env.block.time)?;
+    accumulate_rate_limiter(deps.storage, env, &fp_btc_pk)?;
 
     // Load any type of existing finality signature by the finality provider at the same height
     let existing_finality_sig = get_finality_signature(deps.storage, height, &fp_btc_pk)?;

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -155,7 +155,7 @@ fn ensure_fp_exists_and_not_slashed(
     deps: Deps<BabylonQuery>,
     fp_pubkey_hex: &str,
 ) -> Result<(), ContractError> {
-    let config = get_config(deps)?;
+    let config = get_config(deps.storage)?;
     let fp = query_finality_provider(deps, fp_pubkey_hex.to_string());
     match fp {
         // the finality provider is found but is associated with other BSNs

--- a/contracts/finality/src/exec/finality.rs
+++ b/contracts/finality/src/exec/finality.rs
@@ -7,7 +7,7 @@ use crate::state::finality::{
 use crate::state::public_randomness::{
     get_timestamped_pub_rand_commit_for_height, insert_pub_rand_value, PubRandCommit,
 };
-use crate::state::rate_limiting::accumulate_rate_limiter;
+use crate::state::rate_limiting::check_rate_limit_and_accumulate;
 use crate::utils::{get_fp_fin_vote_context_v0, query_finality_provider};
 use babylon_bindings::BabylonQuery;
 use babylon_merkle::Proof;
@@ -32,8 +32,8 @@ pub fn handle_finality_signature(
 
     let fp_btc_pk = hex::decode(fp_btc_pk_hex)?;
 
-    // Ensure rate limiting; this step will fail if the rate limit is exceeded
-    accumulate_rate_limiter(deps.storage, env, &fp_btc_pk)?;
+    // Ensure rate limiting and accumulate; this step will fail if the rate limit is exceeded
+    check_rate_limit_and_accumulate(deps.storage, env, &fp_btc_pk)?;
 
     // Load any existing finality signature by the finality provider at the same height
     let existing_finality_sigs = list_finality_signatures(deps.storage, height, &fp_btc_pk)?;

--- a/contracts/finality/src/exec/public_randomness.rs
+++ b/contracts/finality/src/exec/public_randomness.rs
@@ -174,11 +174,12 @@ fn ensure_fp_exists_and_not_slashed(
 pub(crate) mod tests {
     use super::*;
     use crate::contract::tests::mock_deps_babylon;
-    use crate::state::config::{Config, CONFIG};
+    use crate::state::config::{Config, RateLimitingConfig, CONFIG};
     use babylon_test_utils::get_public_randomness_commitment;
     use cosmwasm_std::testing::mock_env;
 
     const MAX_MSGS_PER_INTERVAL: u32 = 100;
+    const RATE_LIMITING_INTERVAL: u64 = 10000;
 
     #[test]
     fn verify_commitment_signature_works() {
@@ -213,7 +214,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -247,7 +251,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -316,7 +323,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -344,7 +354,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -411,7 +424,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -452,7 +468,10 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand,
-            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+                block_interval: RATE_LIMITING_INTERVAL,
+            },
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 

--- a/contracts/finality/src/exec/public_randomness.rs
+++ b/contracts/finality/src/exec/public_randomness.rs
@@ -41,7 +41,7 @@ pub fn handle_public_randomness_commit(
         });
     }
 
-    let config = get_config(deps.as_ref())?;
+    let config = get_config(deps.storage)?;
 
     // Validate the commitment parameters
     validate_pub_rand_commit(start_height, num_pub_rand, commitment, config.min_pub_rand)?;

--- a/contracts/finality/src/exec/public_randomness.rs
+++ b/contracts/finality/src/exec/public_randomness.rs
@@ -3,7 +3,7 @@ use crate::error::ContractError;
 use crate::msg::BabylonMsg;
 use crate::state::config::get_config;
 use crate::state::public_randomness::{insert_pub_rand_commit, PubRandCommit};
-use crate::state::rate_limiting::accumulate_rate_limiter;
+use crate::state::rate_limiting::check_rate_limit_and_accumulate;
 use crate::utils::get_fp_rand_commit_context_v0;
 use crate::utils::query_finality_provider;
 use babylon_bindings::BabylonQuery;
@@ -51,8 +51,8 @@ pub fn handle_public_randomness_commit(
 
     let fp_btc_pk = hex::decode(fp_btc_pk_hex)?;
 
-    // Ensure rate limiting; this step will fail if the rate limit is exceeded
-    accumulate_rate_limiter(deps.storage, env, &fp_btc_pk)?;
+    // Ensure rate limiting and accumulate; this step will fail if the rate limit is exceeded
+    check_rate_limit_and_accumulate(deps.storage, env, &fp_btc_pk)?;
 
     let context = get_fp_rand_commit_context_v0(env)?;
     // Verify signature over the list

--- a/contracts/finality/src/exec/public_randomness.rs
+++ b/contracts/finality/src/exec/public_randomness.rs
@@ -52,7 +52,7 @@ pub fn handle_public_randomness_commit(
     let fp_btc_pk = hex::decode(fp_btc_pk_hex)?;
 
     // Ensure rate limiting; this step will fail if the rate limit is exceeded
-    accumulate_rate_limiter(deps.storage, &fp_btc_pk, env.block.time)?;
+    accumulate_rate_limiter(deps.storage, env, &fp_btc_pk)?;
 
     let context = get_fp_rand_commit_context_v0(env)?;
     // Verify signature over the list
@@ -178,7 +178,7 @@ pub(crate) mod tests {
     use babylon_test_utils::get_public_randomness_commitment;
     use cosmwasm_std::testing::mock_env;
 
-    const MAX_MSGS_PER_HOUR: u32 = 100;
+    const MAX_MSGS_PER_INTERVAL: u32 = 100;
 
     #[test]
     fn verify_commitment_signature_works() {
@@ -213,7 +213,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -247,7 +247,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -316,7 +316,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -344,7 +344,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -411,7 +411,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -452,7 +452,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand,
-            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 

--- a/contracts/finality/src/exec/public_randomness.rs
+++ b/contracts/finality/src/exec/public_randomness.rs
@@ -178,6 +178,8 @@ pub(crate) mod tests {
     use babylon_test_utils::get_public_randomness_commitment;
     use cosmwasm_std::testing::mock_env;
 
+    const MAX_MSGS_PER_HOUR: u32 = 100;
+
     #[test]
     fn verify_commitment_signature_works() {
         // Define test values
@@ -211,6 +213,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -244,6 +247,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -312,6 +316,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -339,6 +344,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -405,6 +411,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand: get_random_u64(),
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 
@@ -445,6 +452,7 @@ pub(crate) mod tests {
         let config = Config {
             bsn_id: format!("test-{}", get_random_u64()),
             min_pub_rand,
+            max_msgs_per_hour: MAX_MSGS_PER_HOUR,
         };
         CONFIG.save(deps.as_mut().storage, &config).unwrap();
 

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -13,7 +13,7 @@ pub struct InstantiateMsg {
     pub admin: String,
     pub bsn_id: String,
     pub min_pub_rand: u64,
-    pub max_msgs_per_hour: u32,
+    pub max_msgs_per_interval: u32,
 }
 
 #[cw_serde]

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -249,3 +249,36 @@ impl From<BabylonMsg> for CosmosMsg<BabylonMsg> {
         CosmosMsg::Custom(original)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instantiate_msg_validation_rate_limiting_interval_zero() {
+        let msg = InstantiateMsg {
+            admin: "cosmos1admin".to_string(),
+            bsn_id: "valid-bsn_123".to_string(),
+            min_pub_rand: 1,
+            rate_limiting_interval: 0,
+            max_msgs_per_interval: 10,
+        };
+
+        let err = msg.validate().unwrap_err();
+        assert!(matches!(err, ContractError::InvalidRateLimitingInterval(0)));
+    }
+
+    #[test]
+    fn test_instantiate_msg_validation_max_msgs_per_interval_zero() {
+        let msg = InstantiateMsg {
+            admin: "cosmos1admin".to_string(),
+            bsn_id: "valid-bsn_123".to_string(),
+            min_pub_rand: 1,
+            rate_limiting_interval: 1000,
+            max_msgs_per_interval: 0,
+        };
+
+        let err = msg.validate().unwrap_err();
+        assert!(matches!(err, ContractError::InvalidMaxMsgsPerInterval(0)));
+    }
+}

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -13,6 +13,7 @@ pub struct InstantiateMsg {
     pub admin: String,
     pub bsn_id: String,
     pub min_pub_rand: u64,
+    pub max_msgs_per_hour: u32,
 }
 
 #[cw_serde]

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -1,3 +1,4 @@
+use crate::error::ContractError;
 use babylon_merkle::Proof;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, CosmosMsg};
@@ -13,7 +14,74 @@ pub struct InstantiateMsg {
     pub admin: String,
     pub bsn_id: String,
     pub min_pub_rand: u64,
+    pub rate_limiting_interval: u64,
     pub max_msgs_per_interval: u32,
+}
+
+impl InstantiateMsg {
+    const MAX_BSN_ID_LENGTH: usize = 100;
+
+    /// Validates that a BSN ID has a valid format (non-empty, valid characters, etc.)
+    fn validate_bsn_id_format(&self) -> Result<(), ContractError> {
+        if self.bsn_id.is_empty() {
+            return Err(ContractError::InvalidBsnId(
+                "BSN ID cannot be empty".to_string(),
+            ));
+        }
+
+        // Check for valid characters (alphanumeric, hyphens, underscores)
+        if !self
+            .bsn_id
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(ContractError::InvalidBsnId(
+                "BSN ID can only contain alphanumeric characters, hyphens, and underscores"
+                    .to_string(),
+            ));
+        }
+
+        // Check length (reasonable bounds)
+        if self.bsn_id.len() > Self::MAX_BSN_ID_LENGTH {
+            return Err(ContractError::InvalidBsnId(
+                "BSN ID cannot exceed {MAX_BSN_ID_LENGTH} characters".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_min_pub_rand(&self) -> Result<(), ContractError> {
+        if self.min_pub_rand == 0 {
+            return Err(ContractError::InvalidMinPubRand(self.min_pub_rand));
+        }
+        Ok(())
+    }
+
+    fn validate_rate_limiting(&self) -> Result<(), ContractError> {
+        if self.rate_limiting_interval == 0 {
+            return Err(ContractError::InvalidRateLimitingInterval(
+                self.rate_limiting_interval,
+            ));
+        }
+        if self.max_msgs_per_interval == 0 {
+            return Err(ContractError::InvalidMaxMsgsPerInterval(
+                self.max_msgs_per_interval,
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<(), ContractError> {
+        // Validate min_pub_rand
+        self.validate_min_pub_rand()?;
+        // Validate BSN ID format
+        self.validate_bsn_id_format()?;
+        // Validate rate limiting settings
+        self.validate_rate_limiting()?;
+
+        Ok(())
+    }
 }
 
 #[cw_serde]

--- a/contracts/finality/src/state/config.rs
+++ b/contracts/finality/src/state/config.rs
@@ -12,6 +12,7 @@ pub(crate) const CONFIG: Item<Config> = Item::new("config");
 pub struct Config {
     pub bsn_id: String,
     pub min_pub_rand: u64,
+    pub max_msgs_per_hour: u32,
 }
 
 pub fn get_config(deps: Deps<BabylonQuery>) -> StdResult<Config> {

--- a/contracts/finality/src/state/config.rs
+++ b/contracts/finality/src/state/config.rs
@@ -15,8 +15,8 @@ pub struct Config {
     pub max_msgs_per_hour: u32,
 }
 
-pub fn get_config(deps: Deps<BabylonQuery>) -> StdResult<Config> {
-    CONFIG.load(deps.storage)
+pub fn get_config(storage: &dyn Storage) -> StdResult<Config> {
+    CONFIG.load(storage)
 }
 
 pub fn set_config(storage: &mut dyn Storage, config: &Config) -> StdResult<()> {

--- a/contracts/finality/src/state/config.rs
+++ b/contracts/finality/src/state/config.rs
@@ -12,7 +12,7 @@ pub(crate) const CONFIG: Item<Config> = Item::new("config");
 pub struct Config {
     pub bsn_id: String,
     pub min_pub_rand: u64,
-    pub max_msgs_per_hour: u32,
+    pub max_msgs_per_interval: u32,
 }
 
 pub fn get_config(storage: &dyn Storage) -> StdResult<Config> {

--- a/contracts/finality/src/state/config.rs
+++ b/contracts/finality/src/state/config.rs
@@ -7,12 +7,20 @@ use cw_storage_plus::Item;
 pub(crate) const ADMIN: Admin = Admin::new("admin");
 pub(crate) const CONFIG: Item<Config> = Item::new("config");
 
-/// Config are OP finality gadget's configuration
+#[cw_serde]
+/// RateLimitingConfig defines parameters for rate limiting message processing
+pub struct RateLimitingConfig {
+    /// Maximum number of messages allowed from each FP per interval
+    pub max_msgs_per_interval: u32,
+    /// Number of Babylon blocks in each interval
+    pub block_interval: u64,
+}
+
 #[cw_serde]
 pub struct Config {
     pub bsn_id: String,
     pub min_pub_rand: u64,
-    pub max_msgs_per_interval: u32,
+    pub rate_limiting: RateLimitingConfig,
 }
 
 pub fn get_config(storage: &dyn Storage) -> StdResult<Config> {

--- a/contracts/finality/src/state/mod.rs
+++ b/contracts/finality/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod finality;
 pub mod public_randomness;
+pub mod rate_limiting;
 
 /// `Bytes` is a vector of bytes
 pub type Bytes = Vec<u8>;

--- a/contracts/finality/src/state/rate_limiting.rs
+++ b/contracts/finality/src/state/rate_limiting.rs
@@ -23,7 +23,7 @@ const NUM_MSGS_LAST_INTERVAL: Map<&[u8], (u64, u32)> = Map::new("num_msgs_last_i
 /// * `Ok(())` if the rate limit is not exceeded
 /// * `Err(ContractError::RateLimitExceeded)` if adding one more message would exceed
 ///   the maximum allowed messages per interval (max_msgs_per_interval)
-pub fn accumulate_rate_limiter(
+pub fn check_rate_limit_and_accumulate(
     storage: &mut dyn Storage,
     env: &Env,
     fp_btc_pk: &[u8],
@@ -59,4 +59,257 @@ pub fn accumulate_rate_limiter(
     NUM_MSGS_LAST_INTERVAL.save(storage, fp_btc_pk, &(new_interval, new_count))?;
 
     Ok(())
+}
+
+/// Gets the current rate limiting information for a specific finality provider.
+///
+/// # Arguments
+/// * `storage` - Reference to the contract's storage
+/// * `fp_btc_pk` - The Bitcoin public key of the finality provider
+///
+/// # Returns
+/// * `Ok(Some((u64, u32)))` containing the current interval and message count for the finality provider
+/// * `Ok(None)` if no record exists for this finality provider
+/// * `Err(ContractError)` if there's an error accessing storage
+pub fn get_rate_limit_info(
+    storage: &dyn Storage,
+    fp_btc_pk: &[u8],
+) -> Result<Option<(u64, u32)>, ContractError> {
+    Ok(NUM_MSGS_LAST_INTERVAL.may_load(storage, fp_btc_pk)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::config::{set_config, Config, RateLimitingConfig};
+    use crate::testutil::datagen::get_random_fp_pk;
+    use cosmwasm_std::testing::{mock_env, MockStorage};
+    use cosmwasm_std::Env;
+    use rand::{rng, Rng};
+
+    fn setup_test_env_and_storage(
+        block_height: u64,
+        max_msgs_per_interval: u32,
+        block_interval: u64,
+    ) -> (Env, MockStorage) {
+        let mut env = mock_env();
+        env.block.height = block_height;
+
+        let mut storage = MockStorage::new();
+        let config = Config {
+            bsn_id: "test-bsn".to_string(),
+            min_pub_rand: 10,
+            rate_limiting: RateLimitingConfig {
+                max_msgs_per_interval,
+                block_interval,
+            },
+        };
+        set_config(&mut storage, &config).unwrap();
+
+        (env, storage)
+    }
+
+    #[test]
+    fn test_basic_edge_cases() {
+        // Test nonexistent FP returns None
+        let (_, storage) = setup_test_env_and_storage(100, 5, 10);
+        let fp_btc_pk = get_random_fp_pk();
+        let info = get_rate_limit_info(&storage, &fp_btc_pk).unwrap();
+        assert!(info.is_none());
+
+        // Test zero height edge case
+        let (env, mut storage) = setup_test_env_and_storage(0, 5, 10);
+        let fp_btc_pk = get_random_fp_pk();
+        assert!(check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk).is_ok());
+        let info = get_rate_limit_info(&storage, &fp_btc_pk).unwrap().unwrap();
+        assert_eq!(info, (0, 1));
+    }
+
+    #[test]
+    fn test_randomized_rate_limiting() {
+        let mut rng = rng();
+
+        for iteration in 0..100 {
+            // Randomize test parameters to cover wide range of scenarios
+            let max_msgs = rng.random_range(1..=15);
+            let block_interval = rng.random_range(1..=50);
+            let starting_height = rng.random_range(0..=500);
+
+            let (mut env, mut storage) =
+                setup_test_env_and_storage(starting_height, max_msgs, block_interval);
+            let fp_btc_pk = get_random_fp_pk();
+
+            // Test normal operation within limit
+            for i in 1..=max_msgs {
+                let result = check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk);
+                assert!(
+                    result.is_ok(),
+                    "Iteration {}: Message {} should succeed within limit of {}",
+                    iteration,
+                    i,
+                    max_msgs
+                );
+
+                let info = get_rate_limit_info(&storage, &fp_btc_pk).unwrap().unwrap();
+                let expected_interval = starting_height / block_interval;
+                assert_eq!(info, (expected_interval, i));
+            }
+
+            // Test exceeding limit
+            let result = check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk);
+            assert!(
+                result.is_err(),
+                "Iteration {}: Message beyond limit should fail",
+                iteration
+            );
+            assert!(matches!(
+                result.unwrap_err(),
+                ContractError::RateLimitExceeded { .. }
+            ));
+
+            // Test interval transition resets count
+            let jump_blocks = rng.random_range(1..=3) * block_interval;
+            env.block.height += jump_blocks;
+
+            let result = check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk);
+            assert!(
+                result.is_ok(),
+                "Iteration {}: First message in new interval should succeed",
+                iteration
+            );
+
+            let info = get_rate_limit_info(&storage, &fp_btc_pk).unwrap().unwrap();
+            let expected_new_interval = env.block.height / block_interval;
+            assert_eq!(info, (expected_new_interval, 1));
+        }
+    }
+
+    #[test]
+    fn test_randomized_multiple_fps_and_block_progression() {
+        let mut rng = rng();
+
+        for scenario in 0..25 {
+            let max_msgs = rng.random_range(2..=6);
+            let block_interval = rng.random_range(10..=100);
+            let (mut env, mut storage) = setup_test_env_and_storage(0, max_msgs, block_interval);
+
+            // Generate multiple random finality providers
+            let fps: Vec<Vec<u8>> = (0..rng.random_range(5..=20))
+                .map(|_| get_random_fp_pk())
+                .collect();
+            let mut fp_counts = vec![0u32; fps.len()];
+            let mut current_interval = 0;
+
+            // Perform operations with block progression
+            for step in 0..rng.random_range(100..=300) {
+                // Randomly advance block occasionally
+                if rng.random_range(0..10) == 0 {
+                    let block_jump = rng.random_range(1..=block_interval * 2);
+                    env.block.height += block_jump;
+
+                    let new_interval = env.block.height / block_interval;
+                    if new_interval != current_interval {
+                        current_interval = new_interval;
+                        fp_counts.fill(0); // Reset all counts in new interval
+                    }
+                }
+
+                let fp_index = rng.random_range(0..fps.len());
+                let fp = &fps[fp_index];
+                let result = check_rate_limit_and_accumulate(&mut storage, &env, fp);
+
+                if fp_counts[fp_index] < max_msgs {
+                    // Should succeed
+                    assert!(
+                        result.is_ok(),
+                        "Scenario {}, Step {}: FP {} should succeed with count {}",
+                        scenario,
+                        step,
+                        fp_index,
+                        fp_counts[fp_index]
+                    );
+                    fp_counts[fp_index] += 1;
+
+                    let info = get_rate_limit_info(&storage, fp).unwrap().unwrap();
+                    assert_eq!(info, (current_interval, fp_counts[fp_index]));
+                } else {
+                    // Should fail due to rate limit
+                    assert!(
+                        result.is_err(),
+                        "Scenario {}, Step {}: FP {} should fail with count {}",
+                        scenario,
+                        step,
+                        fp_index,
+                        fp_counts[fp_index]
+                    );
+                    assert!(matches!(
+                        result.unwrap_err(),
+                        ContractError::RateLimitExceeded { .. }
+                    ));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_randomized_edge_cases_and_boundaries() {
+        let mut rng = rng();
+
+        // Test extreme values and edge cases
+        for _ in 0..20 {
+            let max_msgs = if rng.random_range(0..2) == 0 {
+                1
+            } else {
+                rng.random_range(1..=u32::MAX.min(1000))
+            };
+            let block_interval = rng.random_range(1..=100);
+            let block_height = rng.random_range(0..=1000);
+
+            let (env, mut storage) =
+                setup_test_env_and_storage(block_height, max_msgs, block_interval);
+            let fp_btc_pk = get_random_fp_pk();
+
+            if max_msgs == 1 {
+                // First message should succeed
+                assert!(check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk).is_ok());
+                // Second message should fail
+                let err =
+                    check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk).unwrap_err();
+                assert!(matches!(err, ContractError::RateLimitExceeded { .. }));
+            } else {
+                // Should be able to send max_msgs messages
+                for _ in 0..max_msgs.min(100) {
+                    let result = check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk);
+                    assert!(result.is_ok());
+                }
+            }
+        }
+
+        // Test interval calculation edge cases
+        let edge_cases = vec![
+            (0, 10, 0),
+            (9, 10, 0),
+            (10, 10, 1),
+            (19, 10, 1),
+            (20, 10, 2),
+            (100, 1, 100),
+            (100, 100, 1),
+            (1, 1, 1),
+            (999, 1000, 0),
+        ];
+
+        for (block_height, block_interval, expected_interval) in edge_cases {
+            let (env, mut storage) = setup_test_env_and_storage(block_height, 5, block_interval);
+            let fp_btc_pk = get_random_fp_pk();
+
+            assert!(check_rate_limit_and_accumulate(&mut storage, &env, &fp_btc_pk).is_ok());
+
+            let info = get_rate_limit_info(&storage, &fp_btc_pk).unwrap().unwrap();
+            assert_eq!(
+                info.0, expected_interval,
+                "Block {} with interval {} should be in interval {}",
+                block_height, block_interval, expected_interval
+            );
+        }
+    }
 }

--- a/contracts/finality/src/state/rate_limiting.rs
+++ b/contracts/finality/src/state/rate_limiting.rs
@@ -1,0 +1,62 @@
+use cosmwasm_std::{Storage, Timestamp};
+use cw_storage_plus::Map;
+
+use crate::error::ContractError;
+
+/// Stores the number of messages processed for each finality provider within the last hour
+/// Key: Finality Provider's BTC public key
+/// Value: Tuple of (hour number, message count)
+const NUM_MSGS_LAST_HOUR: Map<&[u8], (u64, u32)> = Map::new("num_msgs_last_hour");
+
+/// Maximum number of messages allowed per hour per finality provider
+const MAX_MSGS_PER_HOUR: u32 = 100;
+
+/// Increments the message counter for a finality provider and enforces rate limiting.
+///
+/// This function tracks the number of messages processed for each finality provider
+/// within an hourly window. It increments the counter for the current hour and
+/// resets it when a new hour begins.
+///
+/// # Arguments
+/// * `storage` - Mutable reference to the contract's storage
+/// * `fp_btc_pk` - The Bitcoin public key of the finality provider
+/// * `current_time` - The current timestamp used to determine the hour
+///
+/// # Returns
+/// * `Ok(())` if the rate limit is not exceeded
+/// * `Err(ContractError::RateLimitExceeded)` if adding one more message would exceed
+///   the maximum allowed messages per hour (MAX_MSGS_PER_HOUR)
+pub fn accumulate_rate_limiter(
+    storage: &mut dyn Storage,
+    fp_btc_pk: &[u8],
+    current_time: Timestamp,
+) -> Result<(), ContractError> {
+    let current_hour = current_time.seconds() / 3600;
+
+    // Get existing record or initialize if it's a new FP or new hour
+    let (hour, count) = NUM_MSGS_LAST_HOUR
+        .may_load(storage, fp_btc_pk)?
+        .unwrap_or((current_hour, 0));
+
+    // Determine if it's a new hour and set the appropriate count
+    let (new_hour, new_count) = if hour == current_hour {
+        // Same hour, use existing count
+        (hour, count + 1)
+    } else {
+        // New hour, reset count
+        (current_hour, 1)
+    };
+
+    // Check if adding one more would exceed the limit
+    if new_count > MAX_MSGS_PER_HOUR {
+        return Err(ContractError::RateLimitExceeded {
+            fp_btc_pk: hex::encode(fp_btc_pk),
+            limit: MAX_MSGS_PER_HOUR,
+        });
+    }
+
+    // Increment the counter and save
+    NUM_MSGS_LAST_HOUR.save(storage, fp_btc_pk, &(new_hour, new_count))?;
+
+    Ok(())
+}

--- a/contracts/finality/src/state/rate_limiting.rs
+++ b/contracts/finality/src/state/rate_limiting.rs
@@ -1,60 +1,64 @@
-use cosmwasm_std::{Storage, Timestamp};
+use crate::{error::ContractError, state::config::get_config};
+use cosmwasm_std::{Env, Storage};
+
 use cw_storage_plus::Map;
 
-use crate::{error::ContractError, state::config::get_config};
-
-/// Stores the number of messages processed for each finality provider within the last hour
+/// Stores the number of messages processed for each finality provider within the last block interval
 /// Key: Finality Provider's BTC public key
-/// Value: Tuple of (hour number, message count)
-const NUM_MSGS_LAST_HOUR: Map<&[u8], (u64, u32)> = Map::new("num_msgs_last_hour");
+/// Value: Tuple of (block interval number, message count)
+const NUM_MSGS_LAST_INTERVAL: Map<&[u8], (u64, u32)> = Map::new("num_msgs_last_interval");
+
+/// The number of blocks that define a rate limiting interval
+const RATE_LIMIT_BLOCK_INTERVAL: u64 = 10000;
 
 /// Increments the message counter for a finality provider and enforces rate limiting.
 ///
 /// This function tracks the number of messages processed for each finality provider
-/// within an hourly window. It increments the counter for the current hour and
-/// resets it when a new hour begins.
+/// within a block interval window. It increments the counter for the current interval and
+/// resets it when a new interval begins.
 ///
 /// # Arguments
 /// * `storage` - Mutable reference to the contract's storage
 /// * `fp_btc_pk` - The Bitcoin public key of the finality provider
-/// * `current_time` - The current timestamp used to determine the hour
+/// * `env` - The environment containing block height information
 ///
 /// # Returns
 /// * `Ok(())` if the rate limit is not exceeded
 /// * `Err(ContractError::RateLimitExceeded)` if adding one more message would exceed
-///   the maximum allowed messages per hour (MAX_MSGS_PER_HOUR)
+///   the maximum allowed messages per interval (max_msgs_per_interval)
 pub fn accumulate_rate_limiter(
     storage: &mut dyn Storage,
+    env: &Env,
     fp_btc_pk: &[u8],
-    current_time: Timestamp,
 ) -> Result<(), ContractError> {
-    let current_hour = current_time.seconds() / 3600;
+    let current_block_height = env.block.height;
+    let current_interval = current_block_height / RATE_LIMIT_BLOCK_INTERVAL;
 
-    // Get existing record or initialize if it's a new FP or new hour
-    let (hour, count) = NUM_MSGS_LAST_HOUR
+    // Get existing record or initialize if it's a new FP or new interval
+    let (interval, count) = NUM_MSGS_LAST_INTERVAL
         .may_load(storage, fp_btc_pk)?
-        .unwrap_or((current_hour, 0));
+        .unwrap_or((current_interval, 0));
 
-    // Determine if it's a new hour and set the appropriate count
-    let (new_hour, new_count) = if hour == current_hour {
-        // Same hour, use existing count
-        (hour, count + 1)
+    // Determine if it's a new interval and set the appropriate count
+    let (new_interval, new_count) = if interval == current_interval {
+        // Same interval, use existing count
+        (interval, count + 1)
     } else {
-        // New hour, reset count
-        (current_hour, 1)
+        // New interval, reset count
+        (current_interval, 1)
     };
 
     // Check if adding one more would exceed the limit
-    let max_msgs_per_hour = get_config(storage)?.max_msgs_per_hour;
-    if new_count > max_msgs_per_hour {
+    let max_msgs_per_interval = get_config(storage)?.max_msgs_per_interval;
+    if new_count > max_msgs_per_interval {
         return Err(ContractError::RateLimitExceeded {
             fp_btc_pk: hex::encode(fp_btc_pk),
-            limit: max_msgs_per_hour,
+            limit: max_msgs_per_interval,
         });
     }
 
     // Increment the counter and save
-    NUM_MSGS_LAST_HOUR.save(storage, fp_btc_pk, &(new_hour, new_count))?;
+    NUM_MSGS_LAST_INTERVAL.save(storage, fp_btc_pk, &(new_interval, new_count))?;
 
     Ok(())
 }

--- a/contracts/finality/src/utils.rs
+++ b/contracts/finality/src/utils.rs
@@ -1,4 +1,3 @@
-use crate::error::ContractError;
 use anybuf::{Anybuf, Bufany};
 use babylon_bindings::BabylonQuery;
 use cosmwasm_std::{Binary, Deps, Env, StdResult};
@@ -43,36 +42,6 @@ pub fn query_finality_provider(
     };
 
     Ok(res)
-}
-
-const MAX_BSN_ID_LENGTH: usize = 100;
-
-/// Validates that a BSN ID has a valid format (non-empty, valid characters, etc.)
-pub fn validate_bsn_id_format(bsn_id: &str) -> Result<(), ContractError> {
-    if bsn_id.is_empty() {
-        return Err(ContractError::InvalidBsnId(
-            "BSN ID cannot be empty".to_string(),
-        ));
-    }
-
-    // Check for valid characters (alphanumeric, hyphens, underscores)
-    if !bsn_id
-        .chars()
-        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
-    {
-        return Err(ContractError::InvalidBsnId(
-            "BSN ID can only contain alphanumeric characters, hyphens, and underscores".to_string(),
-        ));
-    }
-
-    // Check length (reasonable bounds)
-    if bsn_id.len() > MAX_BSN_ID_LENGTH {
-        return Err(ContractError::InvalidBsnId(
-            "BSN ID cannot exceed {MAX_BSN_ID_LENGTH} characters".to_string(),
-        ));
-    }
-
-    Ok(())
 }
 
 impl FinalityProviderResponse {

--- a/contracts/finality/tests/integration.rs
+++ b/contracts/finality/tests/integration.rs
@@ -39,6 +39,7 @@ fn instantiate_works() {
         bsn_id: "op-stack-l2-11155420".to_string(),
         min_pub_rand: 100,
         max_msgs_per_interval: 100,
+        rate_limiting_interval: 10000,
     };
     let info = mock_info(CREATOR, &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg.clone());

--- a/contracts/finality/tests/integration.rs
+++ b/contracts/finality/tests/integration.rs
@@ -38,7 +38,7 @@ fn instantiate_works() {
         admin: mock_api.addr_make(CREATOR),
         bsn_id: "op-stack-l2-11155420".to_string(),
         min_pub_rand: 100,
-        max_msgs_per_hour: 100,
+        max_msgs_per_interval: 100,
     };
     let info = mock_info(CREATOR, &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg.clone());

--- a/contracts/finality/tests/integration.rs
+++ b/contracts/finality/tests/integration.rs
@@ -38,6 +38,7 @@ fn instantiate_works() {
         admin: mock_api.addr_make(CREATOR),
         bsn_id: "op-stack-l2-11155420".to_string(),
         min_pub_rand: 100,
+        max_msgs_per_hour: 100,
     };
     let info = mock_info(CREATOR, &[]);
     let res: ContractResult<Response> = instantiate(&mut deps, mock_env(), info, msg.clone());

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -269,8 +269,8 @@ func (s *FinalityContractTestSuite) deployContracts(
 	// init message
 	bsnID := "test-consumer"
 	minPubRand := uint64(100)
-	maxMsgsPerHour := uint32(100)
-	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand, maxMsgsPerHour)
+	maxMsgsPerInterval := uint32(100)
+	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand, maxMsgsPerInterval)
 	initMsgBz := []byte(initMsg)
 	// instantiate contract
 	contractKeeper := keeper.NewDefaultPermissionKeeper(s.babylonApp.WasmKeeper)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -360,8 +360,9 @@ func (s *FinalityContractTestSuite) deployContracts(
 	// init message
 	bsnID := "test-consumer"
 	minPubRand := uint64(100)
+	rateLimitingInterval := uint64(10000)
 	maxMsgsPerInterval := uint32(100)
-	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand, maxMsgsPerInterval)
+	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand, rateLimitingInterval, maxMsgsPerInterval)
 	initMsgBz := []byte(initMsg)
 	// instantiate contract
 	contractKeeper := keeper.NewDefaultPermissionKeeper(s.babylonApp.WasmKeeper)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -269,7 +269,8 @@ func (s *FinalityContractTestSuite) deployContracts(
 	// init message
 	bsnID := "test-consumer"
 	minPubRand := uint64(100)
-	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand)
+	maxMsgsPerHour := uint32(100)
+	initMsg := NewInitMsg(s.owner.String(), bsnID, minPubRand, maxMsgsPerHour)
 	initMsgBz := []byte(initMsg)
 	// instantiate contract
 	contractKeeper := keeper.NewDefaultPermissionKeeper(s.babylonApp.WasmKeeper)

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cometbft/cometbft/crypto/merkle"
 )
 
-func NewInitMsg(admin string, bsnID string, minPubRand uint64) string {
-	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d}`, admin, bsnID, minPubRand)
+func NewInitMsg(admin string, bsnID string, minPubRand uint64, maxMsgsPerHour uint32) string {
+	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d,"max_msgs_per_hour":%d}`, admin, bsnID, minPubRand, maxMsgsPerHour)
 	return initMsg
 }
 

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cometbft/cometbft/crypto/merkle"
 )
 
-func NewInitMsg(admin string, bsnID string, minPubRand uint64, maxMsgsPerInterval uint32) string {
-	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d,"max_msgs_per_interval":%d}`, admin, bsnID, minPubRand, maxMsgsPerInterval)
+func NewInitMsg(admin string, bsnID string, minPubRand uint64, rateLimitingInterval uint64, maxMsgsPerInterval uint32) string {
+	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d,"rate_limiting_interval":%d,"max_msgs_per_interval":%d}`, admin, bsnID, minPubRand, rateLimitingInterval, maxMsgsPerInterval)
 	return initMsg
 }
 

--- a/e2e/types.go
+++ b/e2e/types.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cometbft/cometbft/crypto/merkle"
 )
 
-func NewInitMsg(admin string, bsnID string, minPubRand uint64, maxMsgsPerHour uint32) string {
-	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d,"max_msgs_per_hour":%d}`, admin, bsnID, minPubRand, maxMsgsPerHour)
+func NewInitMsg(admin string, bsnID string, minPubRand uint64, maxMsgsPerInterval uint32) string {
+	initMsg := fmt.Sprintf(`{"admin":"%s","bsn_id":"%s","min_pub_rand":%d,"max_msgs_per_interval":%d}`, admin, bsnID, minPubRand, maxMsgsPerInterval)
 	return initMsg
 }
 


### PR DESCRIPTION
## Description

<!-- Brief description of changes -->

This PR introduces rate limiting on the number of msgs that a FP can submit within each time interval. This includes

- config for rate limiting, including the interval and the max number of msgs per interval
- extending instantiation msg for supplying rate limiting config
- rate limiting KV store. It is a simple counter where key is FP PK and value is a tuple of interval number and count. The interval number is determined by height / interval
- a single function for checking rate limiting and accumulating the counter
- checking rate limiting for both pub rand commit and finality sig

This PR also provides unit tests for instantiation msg and rate limiting, and updates e2e tests.

Resolves #77

## Checklist

- [x] I have updated the [SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/SPEC.md) file if this change affects the specification
- [x] I have updated the schema by running `cargo gen-schema`
