### PR TITLE
core: reduce mutable config params

### DIFF
--- a/contracts/finality/schema/finality.json
+++ b/contracts/finality/schema/finality.json
@@ -336,24 +336,6 @@
           "update_config": {
             "type": "object",
             "properties": {
-              "bsn_activation_height": {
-                "description": "New BSN activation height (if provided)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "finality_signature_interval": {
-                "description": "New finality signature interval (if provided)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
               "max_msgs_per_interval": {
                 "description": "New maximum messages per finality provider per interval (if provided)",
                 "type": [

--- a/contracts/finality/schema/raw/execute.json
+++ b/contracts/finality/schema/raw/execute.json
@@ -266,24 +266,6 @@
         "update_config": {
           "type": "object",
           "properties": {
-            "bsn_activation_height": {
-              "description": "New BSN activation height (if provided)",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "finality_signature_interval": {
-              "description": "New finality signature interval (if provided)",
-              "type": [
-                "integer",
-                "null"
-              ],
-              "format": "uint64",
-              "minimum": 0.0
-            },
             "max_msgs_per_interval": {
               "description": "New maximum messages per finality provider per interval (if provided)",
               "type": [

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -186,16 +186,12 @@ pub fn execute(
             min_pub_rand,
             max_msgs_per_interval,
             rate_limiting_interval,
-            bsn_activation_height,
-            finality_signature_interval,
         } => handle_update_config(
             deps,
             info,
             min_pub_rand,
             max_msgs_per_interval,
             rate_limiting_interval,
-            bsn_activation_height,
-            finality_signature_interval,
         ),
     }
 }
@@ -1095,8 +1091,6 @@ pub(crate) mod tests {
             min_pub_rand: Some(200),
             max_msgs_per_interval: None,
             rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let admin_info = message_info(&admin, &[]);
         let res = execute(deps.as_mut(), mock_env(), admin_info.clone(), update_msg).unwrap();
@@ -1110,19 +1104,12 @@ pub(crate) mod tests {
         let config: Config = from_json(config_query).unwrap();
         assert_eq!(config.bsn_id, bsn_id); // unchanged
         assert_eq!(config.min_pub_rand, 200); // updated
-        assert_eq!(config.bsn_activation_height, bsn_activation_height); // unchanged
-        assert_eq!(
-            config.finality_signature_interval,
-            finality_signature_interval
-        ); // unchanged
 
         // Test 2: Update multiple fields at once
         let update_msg = ExecuteMsg::UpdateConfig {
             min_pub_rand: Some(300),
             max_msgs_per_interval: Some(150),
             rate_limiting_interval: Some(15000),
-            bsn_activation_height: Some(2000),
-            finality_signature_interval: Some(200),
         };
         let res = execute(deps.as_mut(), mock_env(), admin_info.clone(), update_msg).unwrap();
 
@@ -1137,8 +1124,6 @@ pub(crate) mod tests {
         assert_eq!(config.min_pub_rand, 300);
         assert_eq!(config.rate_limiting.max_msgs_per_interval, 150);
         assert_eq!(config.rate_limiting.block_interval, 15000);
-        assert_eq!(config.bsn_activation_height, 2000);
-        assert_eq!(config.finality_signature_interval, 200);
 
         // Test 3: Non-admin cannot update config
         let non_admin_info = message_info(&non_admin, &[]);
@@ -1146,8 +1131,6 @@ pub(crate) mod tests {
             min_pub_rand: Some(999),
             max_msgs_per_interval: None,
             rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let err = execute(deps.as_mut(), mock_env(), non_admin_info, update_msg).unwrap_err();
         assert_eq!(err, ContractError::Admin(AdminError::NotAdmin {}));
@@ -1157,8 +1140,6 @@ pub(crate) mod tests {
             min_pub_rand: None,
             max_msgs_per_interval: None,
             rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let err = execute(deps.as_mut(), mock_env(), admin_info, empty_update_msg).unwrap_err();
         assert_eq!(err, ContractError::NoConfigFieldsToUpdate);
@@ -1191,8 +1172,6 @@ pub(crate) mod tests {
             min_pub_rand: Some(0), // invalid: must be > 0
             max_msgs_per_interval: None,
             rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let err = execute(
             deps.as_mut(),
@@ -1208,8 +1187,6 @@ pub(crate) mod tests {
             min_pub_rand: None,
             max_msgs_per_interval: Some(0), // invalid: must be > 0
             rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let err = execute(
             deps.as_mut(),
@@ -1225,8 +1202,6 @@ pub(crate) mod tests {
             min_pub_rand: None,
             max_msgs_per_interval: None,
             rate_limiting_interval: Some(0), // invalid: must be > 0
-            bsn_activation_height: None,
-            finality_signature_interval: None,
         };
         let err = execute(
             deps.as_mut(),
@@ -1236,23 +1211,6 @@ pub(crate) mod tests {
         )
         .unwrap_err();
         assert_eq!(err, ContractError::InvalidRateLimitingInterval(0));
-
-        // Test invalid finality_signature_interval
-        let invalid_finality_interval_update = ExecuteMsg::UpdateConfig {
-            min_pub_rand: None,
-            max_msgs_per_interval: None,
-            rate_limiting_interval: None,
-            bsn_activation_height: None,
-            finality_signature_interval: Some(0), // invalid: must be > 0
-        };
-        let err = execute(
-            deps.as_mut(),
-            mock_env(),
-            admin_info,
-            invalid_finality_interval_update,
-        )
-        .unwrap_err();
-        assert_eq!(err, ContractError::InvalidFinalitySignatureInterval(0));
     }
 
     #[test]

--- a/contracts/finality/src/exec/config.rs
+++ b/contracts/finality/src/exec/config.rs
@@ -4,8 +4,7 @@ use crate::error::ContractError;
 use crate::msg::BabylonMsg;
 use crate::state::config::{get_config, set_config, ADMIN};
 use crate::validation::{
-    validate_finality_signature_interval, validate_max_msgs_per_interval, validate_min_pub_rand,
-    validate_rate_limiting_interval,
+    validate_max_msgs_per_interval, validate_min_pub_rand, validate_rate_limiting_interval,
 };
 use babylon_bindings::BabylonQuery;
 
@@ -16,8 +15,6 @@ pub fn handle_update_config(
     min_pub_rand: Option<u64>,
     max_msgs_per_interval: Option<u32>,
     rate_limiting_interval: Option<u64>,
-    bsn_activation_height: Option<u64>,
-    finality_signature_interval: Option<u64>,
 ) -> Result<Response<BabylonMsg>, ContractError> {
     // Only admin can update config
     ADMIN.assert_admin(deps.as_ref(), &info.sender)?;
@@ -43,19 +40,6 @@ pub fn handle_update_config(
     if let Some(new_interval) = rate_limiting_interval {
         validate_rate_limiting_interval(new_interval)?;
         config.rate_limiting.block_interval = new_interval;
-        has_updates = true;
-    }
-
-    // Update bsn_activation_height if provided (no validation needed - any u64 is valid)
-    if let Some(new_activation_height) = bsn_activation_height {
-        config.bsn_activation_height = new_activation_height;
-        has_updates = true;
-    }
-
-    // Update finality_signature_interval if provided
-    if let Some(new_finality_interval) = finality_signature_interval {
-        validate_finality_signature_interval(new_finality_interval)?;
-        config.finality_signature_interval = new_finality_interval;
         has_updates = true;
     }
 

--- a/contracts/finality/src/msg.rs
+++ b/contracts/finality/src/msg.rs
@@ -232,10 +232,6 @@ pub enum ExecuteMsg {
         max_msgs_per_interval: Option<u32>,
         /// New rate limiting interval in blocks (if provided)
         rate_limiting_interval: Option<u64>,
-        /// New BSN activation height (if provided)
-        bsn_activation_height: Option<u64>,
-        /// New finality signature interval (if provided)
-        finality_signature_interval: Option<u64>,
     },
 }
 


### PR DESCRIPTION
## Description

This PR reduced mutable config params. `bsn_activation_height` and `finality_signature_interval` should not be mutable

## Checklist

- [ ] I have updated the [docs/SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/docs/SPEC.md) file if this change affects the specification
- [ ] I have updated the schema by running `cargo gen-schema`
