### PR TITLE
core: add allow-list to instantiate arg

### DIFF
--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -46,6 +46,8 @@ pub fn instantiate(
     };
     set_config(deps.storage, &config)?;
 
+    let mut response = Response::new().add_attribute("action", "instantiate");
+
     // Add initial allowed finality providers if provided
     if let Some(fp_list) = msg.allowed_finality_providers {
         // Validate all public keys are not empty
@@ -67,9 +69,11 @@ pub fn instantiate(
             &fp_btc_pk_bytes_list,
             env.block.height,
         )?;
+
+        response = response.add_attribute("allow-list", fp_list.join(","));
     }
 
-    Ok(Response::new().add_attribute("action", "instantiate"))
+    Ok(response)
 }
 
 pub fn query(
@@ -1527,5 +1531,62 @@ pub(crate) mod tests {
         for fp in &fps_at_107 {
             assert!(current_fps.contains(fp));
         }
+    }
+
+    #[test]
+    fn test_instantiate_allowlist_event() {
+        let mut deps = mock_deps_babylon();
+        let admin = deps.api.addr_make(INIT_ADMIN);
+        let bsn_id = "op-stack-l2-11155420".to_string();
+        let min_pub_rand = 100;
+
+        // Test 1: Instantiate with allowed finality providers - should have allow-list attribute
+        let fp_list = vec![
+            "02a0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c7".to_string(),
+            "03b0434d9e47f3c86235477c7b1ae6ae5d3442d49b1943c2b752a68e2a47e247c8".to_string(),
+        ];
+        let expected_allowlist = fp_list.join(",");
+
+        let instantiate_msg = InstantiateMsg {
+            admin: admin.to_string(),
+            bsn_id: bsn_id.clone(),
+            min_pub_rand,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting_interval: RATE_LIMITING_INTERVAL,
+            bsn_activation_height: 1000,
+            finality_signature_interval: 100,
+            allowed_finality_providers: Some(fp_list),
+        };
+
+        let info = message_info(&deps.api.addr_make(CREATOR), &[]);
+        let res = instantiate(deps.as_mut(), mock_env(), info, instantiate_msg).unwrap();
+
+        // Verify response has both action and allow-list attributes
+        assert_eq!(res.attributes.len(), 2);
+        assert_eq!(res.attributes[0].key, "action");
+        assert_eq!(res.attributes[0].value, "instantiate");
+        assert_eq!(res.attributes[1].key, "allow-list");
+        assert_eq!(res.attributes[1].value, expected_allowlist);
+
+        // Test 2: Instantiate without allowed finality providers - should not have allow-list attribute
+        let mut deps2 = mock_deps_babylon();
+        let instantiate_msg2 = InstantiateMsg {
+            admin: admin.to_string(),
+            bsn_id,
+            min_pub_rand,
+            max_msgs_per_interval: MAX_MSGS_PER_INTERVAL,
+            rate_limiting_interval: RATE_LIMITING_INTERVAL,
+            bsn_activation_height: 1000,
+            finality_signature_interval: 100,
+            allowed_finality_providers: None,
+        };
+
+        let info2 = message_info(&deps2.api.addr_make(CREATOR), &[]);
+        let res2 = instantiate(deps2.as_mut(), mock_env(), info2, instantiate_msg2).unwrap();
+
+        // Verify response has only action attribute
+        assert_eq!(res2.attributes.len(), 1);
+        assert_eq!(res2.attributes[0].key, "action");
+        assert_eq!(res2.attributes[0].value, "instantiate");
     }
 }


### PR DESCRIPTION
## Description

This PR adds additional attribute to instantiation event. Argument list all FP which are set on isntantiation. 

cc @gusin13 @SebastianElvis I’m skeptical about the costs, since the list can get quite large (20 to 30 BTC keys). How much of an impact do you think this will have?

## Checklist

- [ ] I have updated the [docs/SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/docs/SPEC.md) file if this change affects the specification
- [ ] I have updated the schema by running `cargo gen-schema`
