### PR TITLE
Enable workflow_dispatch on publish ci pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,13 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Version tag (e.g., v1.0.0)'
+        required: true
+        type: string
+          
 env:
   CARGO_TERM_COLOR: always
   WORKSPACE: "/home/runner/work/rollup-bsn-contracts/rollup-bsn-contracts"
@@ -39,8 +46,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.version_tag || github.ref_name }}
+          release_name: Release ${{ github.event_name == 'workflow_dispatch' && inputs.version_tag || github.ref_name }}
           body: |
             Attached there are some build artifacts generated at this tag.
           draft: false


### PR DESCRIPTION
## Description

Enable workflow_dispatch on publish ci pipeline with the tag as input

## Checklist

- [ ] I have updated the [docs/SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/docs/SPEC.md) file if this change affects the specification
- [ ] I have updated the schema by running `cargo gen-schema`
