### PR TITLE
fix: pre-cw2 migrate validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-* [#114](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/114) feat: migration setup
+* [#114](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/114) feat:
+  migration setup
+* [#117](https://github.com/babylonlabs-io/rollup-bsn-contracts/pull/117) fix:
+  pre-cw2 migrate validations
 
 
 ## v1.0.0-rc.0

--- a/contracts/finality/schema/finality.json
+++ b/contracts/finality/schema/finality.json
@@ -647,17 +647,8 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "description": "Migration message for contract upgrades. This can be extended in the future to include migration-specific parameters.",
+    "description": "Migration message for contract upgrades. Empty for non-state-breaking migrations. Can be extended in the future to include migration-specific parameters for state transformations.",
     "type": "object",
-    "properties": {
-      "version": {
-        "description": "Optional version string for tracking migration",
-        "type": [
-          "string",
-          "null"
-        ]
-      }
-    },
     "additionalProperties": false
   },
   "sudo": null,

--- a/contracts/finality/schema/raw/migrate.json
+++ b/contracts/finality/schema/raw/migrate.json
@@ -1,16 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "description": "Migration message for contract upgrades. This can be extended in the future to include migration-specific parameters.",
+  "description": "Migration message for contract upgrades. Empty for non-state-breaking migrations. Can be extended in the future to include migration-specific parameters for state transformations.",
   "type": "object",
-  "properties": {
-    "version": {
-      "description": "Optional version string for tracking migration",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
   "additionalProperties": false
 }

--- a/contracts/finality/src/contract.rs
+++ b/contracts/finality/src/contract.rs
@@ -126,7 +126,7 @@ pub fn migrate(
 
     Ok(Response::new()
         .add_attribute("action", "migrate")
-        .add_attribute("from_version", &prev_version.version)
+        .add_attribute("from_version", prev_version.version)
         .add_attribute("to_version", CONTRACT_VERSION))
 }
 


### PR DESCRIPTION
## Description

<!-- Brief description of changes -->

## Checklist

- [x] I have updated the [docs/SPEC.md](https://github.com/babylonlabs-io/rollup-bsn-contracts/blob/main/docs/SPEC.md) file if this change affects the specification
- [x] I have updated the schema by running `cargo gen-schema`
